### PR TITLE
feat: piano roll editor

### DIFF
--- a/src/lib/components/editor/editor.svelte
+++ b/src/lib/components/editor/editor.svelte
@@ -7,6 +7,7 @@
     import MouseWindowEvents from './mouse-window-events.svelte';
     import NoteChannelInfo from './note-channel/note-channel-info.svelte';
     import NoteChannel from './note-channel/note-channel.svelte';
+    import NotePianoRoll from './note-channel/note-piano-roll.svelte';
     import PlayheadCursor from './playhead-cursor.svelte';
     import RulerRow from './ruler-row.svelte';
     import SelectionOverlay from './selection-overlay.svelte';
@@ -218,6 +219,8 @@
         </Resizable.Pane>
     </Resizable.PaneGroup>
 </div>
+
+<NotePianoRoll />
 
 <style>
     .scrollbar-hidden::-webkit-scrollbar {

--- a/src/lib/components/editor/note-channel/note-piano-roll.svelte
+++ b/src/lib/components/editor/note-channel/note-piano-roll.svelte
@@ -335,9 +335,6 @@
      - Base `.note-rect` contains the normal appearance. */
 
     .note-rect {
-        transition:
-            background-color 240ms ease,
-            border-color 240ms ease;
         will-change: background-color, border-color;
     }
 
@@ -350,7 +347,9 @@
 
     /* Fade class: transitions from played color back to normal */
     .note-rect.note-playing-fade {
-        background-color: inherit;
-        border-color: inherit;
+        transition:
+            background-color 240ms ease,
+            border-color 240ms ease;
+        /* Let the transition happen naturally to the element's original styles */
     }
 </style>

--- a/src/lib/components/editor/note-channel/note-piano-roll.svelte
+++ b/src/lib/components/editor/note-channel/note-piano-roll.svelte
@@ -1,10 +1,26 @@
 <script lang="ts">
+    import Button from '$lib/components/ui/button/button.svelte';
     import * as Sheet from '$lib/components/ui/sheet';
-    import { editorState } from '$lib/editor-state.svelte';
-    import { player } from '$lib/playback.svelte';
+    import {
+        TooltipContent,
+        TooltipProvider,
+        Tooltip as TooltipRoot,
+        TooltipTrigger
+    } from '$lib/components/ui/tooltip';
+    import { editorState, PointerMode } from '$lib/editor-state.svelte';
+    import { LoopMode, player } from '$lib/playback.svelte';
     import { INSTRUMENT_NAMES, type Note, type NoteChannel, type NoteSection } from '$lib/types';
     import PlayheadCursor from '../playhead-cursor.svelte';
     import TimelineGrid from '../timeline-grid.svelte';
+    import type { Snippet } from 'svelte';
+    import GitMerge from '~icons/lucide/git-merge';
+    import MousePointer from '~icons/lucide/mouse-pointer';
+    import MousePointerClick from '~icons/lucide/mouse-pointer-click';
+    import Pause from '~icons/lucide/pause';
+    import Play from '~icons/lucide/play';
+    import Repeat from '~icons/lucide/repeat';
+    import Scissors from '~icons/lucide/scissors';
+    import SkipBack from '~icons/lucide/skip-back';
 
     type PianoRollContext = {
         channel: NoteChannel;

--- a/src/lib/components/editor/note-channel/note-piano-roll.svelte
+++ b/src/lib/components/editor/note-channel/note-piano-roll.svelte
@@ -169,8 +169,14 @@
                         gutterWidth={96}
                         contentWidth={pianoRollState.contentWidth}
                         scrollLeft={pianoRollState.gridScrollLeft}
-                        pointerDownHandler={(container, event) =>
-                            editorMouse.handleRulerPointerDown(container, event)}
+                        pointerDownHandler={(container, event) => {
+                            const relativeTick = editorMouse.tickFromClientX(
+                                container,
+                                event.clientX
+                            );
+                            const absoluteTick = pianoRollState.sectionStartTick + relativeTick;
+                            player.setCurrentTick(absoluteTick);
+                        }}
                         gutter={pianoRollRulerGutter}
                         on:scrollLeftChange={(event) =>
                             pianoRollState.handleRulerScrollLeft(event.detail)}

--- a/src/lib/components/editor/note-channel/note-piano-roll.svelte
+++ b/src/lib/components/editor/note-channel/note-piano-roll.svelte
@@ -83,15 +83,10 @@
         if (!id) return;
         const nodes = document.querySelectorAll<HTMLElement>(`[data-note-id="${id}"]`);
         nodes.forEach((n) => {
-            // Remove immediate state first so the element currently shows the "played" color.
             n.classList.remove('note-playing-immediate');
-            // Force a reflow so the browser registers the style change before we add the fade class
-            // which will transition from the current (played) color to the default.
             // eslint-disable-next-line @typescript-eslint/no-unused-expressions
             n.offsetHeight;
-            // Add fade class which transitions properties back to normal
             n.classList.add('note-playing-fade');
-            // Cleanup: remove the fade class after transition duration (match CSS below)
             const CLEANUP_MS = 260;
             const idKey = (n as any).__fadeCleanupId;
             if (idKey) clearTimeout(idKey);
@@ -114,20 +109,17 @@
         };
     });
 
-    // Auto-follow playhead in piano roll
     const playheadContentX = $derived.by(() => {
         if (!pianoRollState.sectionData) return 0;
         const relativeTick = player.currentTick - pianoRollState.sectionStartTick;
         return Math.max(0, relativeTick * pianoRollState.pxPerTick);
     });
 
-    // Keep about one beat of space from the left edge when auto-scrolling
     const leftPadding = $derived(
         Math.min(240, Math.max(48, Math.round(editorState.pxPerBeat * 1)))
     );
 
     $effect(() => {
-        // Re-run when playhead moves or viewport changes
         const scroller = pianoRollState.gridScroller;
         if (!scroller || !pianoRollState.sheetOpen) return;
         const viewportWidth = scroller.clientWidth;
@@ -137,16 +129,13 @@
         const right = left + viewportWidth;
         const x = playheadContentX;
 
-        // Only auto-scroll while playing and enabled to avoid fighting manual seeks
         if (!player.isPlaying || !editorState.autoScrollEnabled) return;
 
-        // Only auto-scroll if playhead is within this section
         if (!pianoRollState.cursorVisible) return;
 
-        const isOutOfView = x < left + 4 || x > right - 4; // small margin
+        const isOutOfView = x < left + 4 || x > right - 4;
         if (!isOutOfView) return;
 
-        // Place playhead near the left edge (with padding), clamped to content bounds
         const desired = Math.round(x - leftPadding);
         const maxScroll = Math.max(0, pianoRollState.contentWidth - viewportWidth);
         const clamped = Math.min(maxScroll, Math.max(0, desired));
@@ -260,7 +249,7 @@
                                     {#each pianoRollState.notesToRender as note}
                                         <div
                                             data-note-id={`${pianoRollState.sectionStartTick + note.note.tick}:${note.note.key}:${pianoRollState.sectionData?.channel.instrument ?? 'note'}`}
-                                            class={`absolute z-30 rounded-sm border ${
+                                            class={`note-rect absolute z-30 rounded-sm border ${
                                                 note.selected
                                                     ? 'border-white/70 bg-primary text-primary-foreground shadow-lg'
                                                     : 'border-primary/30 bg-primary/80 shadow-sm'
@@ -359,11 +348,8 @@
         border-color: rgba(0, 160, 255, 0.7) !important;
     }
 
-    /* Fade class: when applied, element will transition from the current (played) look
-     back to the base appearance defined on .note-rect because .note-playing-fade sets
-     the target (normal) values and .note-rect defines the transition. */
+    /* Fade class: transitions from played color back to normal */
     .note-rect.note-playing-fade {
-        /* Target values (normal) so the transitions animate towards these */
         background-color: inherit;
         border-color: inherit;
     }

--- a/src/lib/components/editor/note-channel/note-piano-roll.svelte
+++ b/src/lib/components/editor/note-channel/note-piano-roll.svelte
@@ -8,10 +8,10 @@
     import { onMount } from 'svelte';
     import PlayheadCursor from '../playhead-cursor.svelte';
     import RulerShell from '../ruler-shell.svelte';
+    import SelectionRectangleOverlay from '../selection-rectangle-overlay.svelte';
     import TimelineGrid from '../timeline-grid.svelte';
     import PianoRollHeader from './piano-roll-header.svelte';
     import PianoRollMouseWindowEvents from './piano-roll-mouse-window-events.svelte';
-    import SelectionRectangleOverlay from '../selection-rectangle-overlay.svelte';
 
     $effect(() => {
         pianoRollState.sheetOpen = pianoRollState.pianoRollTarget !== null;
@@ -263,7 +263,7 @@
                                             data-note-id={`${pianoRollState.sectionStartTick + note.note.tick}:${note.note.key}:${pianoRollState.sectionData?.channel.instrument ?? 'note'}`}
                                             class={`note-rect absolute z-30 rounded-sm border ${
                                                 note.selected
-                                                    ? 'border-white/70 bg-primary text-primary-foreground shadow-lg'
+                                                    ? 'scale-105 transform border-yellow-400 bg-yellow-500 text-primary-foreground shadow-2xl ring-4 ring-yellow-400/60 ring-offset-2 ring-offset-background'
                                                     : 'border-primary/30 bg-primary/80 shadow-sm'
                                             }`}
                                             style={`left:${note.left}px; top:${note.top}px; width:${note.width}px; height:${note.height}px;`}
@@ -276,11 +276,13 @@
                                     {/each}
                                 </div>
                             </div>
-                            <SelectionRectangleOverlay
-                                rect={pianoRollMouse.selectionOverlayRect}
-                                scrollLeft={pianoRollState.gridScrollLeft}
-                                scrollTop={pianoRollState.gridScrollTop}
-                            />
+                            {#if pianoRollState.pointerMode === PointerMode.Normal}
+                                <SelectionRectangleOverlay
+                                    rect={pianoRollMouse.selectionOverlayRect}
+                                    scrollLeft={pianoRollState.gridScrollLeft}
+                                    scrollTop={pianoRollState.gridScrollTop}
+                                />
+                            {/if}
                             <PlayheadCursor
                                 gutterWidth={0}
                                 class="z-40"

--- a/src/lib/components/editor/note-channel/note-piano-roll.svelte
+++ b/src/lib/components/editor/note-channel/note-piano-roll.svelte
@@ -11,6 +11,7 @@
     import TimelineGrid from '../timeline-grid.svelte';
     import PianoRollHeader from './piano-roll-header.svelte';
     import PianoRollMouseWindowEvents from './piano-roll-mouse-window-events.svelte';
+    import SelectionRectangleOverlay from '../selection-rectangle-overlay.svelte';
 
     $effect(() => {
         pianoRollState.sheetOpen = pianoRollState.pianoRollTarget !== null;
@@ -234,6 +235,9 @@
                                     class="relative"
                                     style={`width:${pianoRollState.contentWidth}px; height:${pianoRollState.gridHeight}px;`}
                                     onpointerdown={pianoRollMouse.handleBackgroundPointerDown}
+                                    onpointermove={pianoRollMouse.handleGridPointerMove}
+                                    onpointerup={pianoRollMouse.handleGridPointerUp}
+                                    onpointercancel={pianoRollMouse.handleGridPointerCancel}
                                 >
                                     <TimelineGrid
                                         gutterWidth={0}
@@ -270,36 +274,13 @@
                                                 )}
                                         ></div>
                                     {/each}
-
-                                    {#if pianoRollMouse.selectionBox}
-                                        {@const box = pianoRollMouse.selectionBox}
-                                        {@const px =
-                                            pianoRollState.pxPerTick > 0
-                                                ? pianoRollState.pxPerTick
-                                                : 1}
-                                        {@const tickStart = Math.min(
-                                            box.startTick,
-                                            box.currentTick
-                                        )}
-                                        {@const tickEnd =
-                                            Math.max(box.startTick, box.currentTick) + 1}
-                                        {@const keyTop = Math.max(box.startKey, box.currentKey)}
-                                        {@const keyBottom = Math.min(box.startKey, box.currentKey)}
-                                        {@const left = Math.round(tickStart * px)}
-                                        {@const right = Math.round(tickEnd * px)}
-                                        {@const top =
-                                            (pianoRollState.keyRange.max - keyTop) *
-                                            pianoRollState.keyHeight}
-                                        {@const bottom =
-                                            (pianoRollState.keyRange.max - keyBottom + 1) *
-                                            pianoRollState.keyHeight}
-                                        <div
-                                            class="pointer-events-none absolute z-20 border-2 border-indigo-400/70 bg-indigo-500/10"
-                                            style={`left:${Math.min(left, right)}px; top:${Math.min(top, bottom)}px; width:${Math.max(1, Math.abs(right - left))}px; height:${Math.max(1, Math.abs(bottom - top))}px;`}
-                                        ></div>
-                                    {/if}
                                 </div>
                             </div>
+                            <SelectionRectangleOverlay
+                                rect={pianoRollMouse.selectionOverlayRect}
+                                scrollLeft={pianoRollState.gridScrollLeft}
+                                scrollTop={pianoRollState.gridScrollTop}
+                            />
                             <PlayheadCursor
                                 gutterWidth={0}
                                 class="z-40"

--- a/src/lib/components/editor/note-channel/note-piano-roll.svelte
+++ b/src/lib/components/editor/note-channel/note-piano-roll.svelte
@@ -24,6 +24,61 @@
     import RulerShell from '../ruler-shell.svelte';
     import TimelineGrid from '../timeline-grid.svelte';
     import PianoRollMouseWindowEvents from './piano-roll-mouse-window-events.svelte';
+
+    $effect(() => {
+        pianoRollState.sheetOpen = pianoRollState.pianoRollTarget !== null;
+    });
+
+    $effect(() => {
+        if (!pianoRollState.sheetOpen && pianoRollState.pianoRollTarget) {
+            editorState.closePianoRoll();
+        }
+    });
+
+    $effect(() => {
+        if (pianoRollState.pianoRollTarget && !pianoRollState.sectionData) {
+            editorState.closePianoRoll();
+            pianoRollState.sheetOpen = false;
+        }
+    });
+
+    $effect(() => {
+        const grid = pianoRollState.gridScroller;
+        if (!grid) return;
+        if (Math.abs(grid.scrollLeft - pianoRollState.gridScrollLeft) > 1) {
+            grid.scrollLeft = pianoRollState.gridScrollLeft;
+        }
+    });
+
+    $effect(() => {
+        pianoRollMouse.setGridContent(pianoRollState.gridContent);
+    });
+
+    $effect(() => {
+        pianoRollMouse.setSection(pianoRollState.sectionData?.section ?? null);
+    });
+
+    $effect(() => {
+        pianoRollMouse.updateGeometry({
+            pxPerTick: pianoRollState.pxPerTick > 0 ? pianoRollState.pxPerTick : 1,
+            keyRange: pianoRollState.keyRange,
+            keyHeight: pianoRollState.keyHeight
+        });
+    });
+
+    $effect(() => {
+        pianoRollMouse.setActive(pianoRollState.sheetOpen);
+    });
+
+    $effect(() => {
+        pianoRollMouse.setPointerMode(pianoRollState.pointerMode);
+    });
+
+    $effect(() => {
+        if (!pianoRollState.sheetOpen) {
+            pianoRollState.pointerMode = PointerMode.Normal;
+        }
+    });
 </script>
 
 {#snippet tooltipped({

--- a/src/lib/components/editor/note-channel/note-piano-roll.svelte
+++ b/src/lib/components/editor/note-channel/note-piano-roll.svelte
@@ -38,28 +38,13 @@
         }
     });
 
+    // Mouse controller is now stateless - all state managed by pianoRollState
     $effect(() => {
-        pianoRollMouse.setGridContent(pianoRollState.gridContent);
+        pianoRollMouse.setPianoRollState(pianoRollState);
     });
 
     $effect(() => {
-        pianoRollMouse.setSection(pianoRollState.sectionData?.section ?? null);
-    });
-
-    $effect(() => {
-        pianoRollMouse.updateGeometry({
-            pxPerTick: pianoRollState.pxPerTick > 0 ? pianoRollState.pxPerTick : 1,
-            keyRange: pianoRollState.keyRange,
-            keyHeight: pianoRollState.keyHeight
-        });
-    });
-
-    $effect(() => {
-        pianoRollMouse.setActive(pianoRollState.sheetOpen);
-    });
-
-    $effect(() => {
-        pianoRollMouse.setPointerMode(pianoRollState.pointerMode);
+        pianoRollState.isMouseActive = pianoRollState.sheetOpen;
     });
 
     $effect(() => {
@@ -278,7 +263,7 @@
                             </div>
                             {#if pianoRollState.pointerMode === PointerMode.Normal}
                                 <SelectionRectangleOverlay
-                                    rect={pianoRollMouse.selectionOverlayRect}
+                                    rect={pianoRollState.selectionOverlayRect}
                                     scrollLeft={pianoRollState.gridScrollLeft}
                                     scrollTop={pianoRollState.gridScrollTop}
                                 />

--- a/src/lib/components/editor/note-channel/note-piano-roll.svelte
+++ b/src/lib/components/editor/note-channel/note-piano-roll.svelte
@@ -105,6 +105,35 @@
         Math.min(240, Math.max(48, Math.round(editorState.pxPerBeat * 1)))
     );
 
+    function handleKeyDown(event: KeyboardEvent) {
+        // Only handle keyboard events when the piano roll is active
+        if (!pianoRollState.sheetOpen || !pianoRollState.sectionData) return;
+
+        if (event.key === 'Backspace' || event.key === 'Delete') {
+            const section = pianoRollState.sectionData.section;
+            const notes = section.notes;
+            if (!notes?.length || !pianoRollState.selectedNotes.length) return;
+
+            // Prevent default to avoid browser back navigation on backspace
+            event.preventDefault();
+
+            // Remove selected notes
+            const toRemove = new Set(pianoRollState.selectedNotes);
+            let removed = false;
+            for (let index = notes.length - 1; index >= 0; index--) {
+                if (toRemove.has(notes[index]!)) {
+                    notes.splice(index, 1);
+                    removed = true;
+                }
+            }
+
+            if (removed) {
+                pianoRollState.clearSelection();
+                player.refreshIndexes();
+            }
+        }
+    }
+
     $effect(() => {
         const scroller = pianoRollState.gridScroller;
         if (!scroller || !pianoRollState.sheetOpen) return;
@@ -141,6 +170,7 @@
     <Sheet.Content
         side="bottom"
         class="h-[70vh] w-full max-w-none border-t border-border bg-background"
+        onkeydown={handleKeyDown}
     >
         {#if pianoRollState.sectionData}
             <div class="flex h-full flex-col">

--- a/src/lib/components/editor/note-channel/note-piano-roll.svelte
+++ b/src/lib/components/editor/note-channel/note-piano-roll.svelte
@@ -1,28 +1,13 @@
 <script lang="ts">
-    import Button from '$lib/components/ui/button/button.svelte';
     import * as Sheet from '$lib/components/ui/sheet';
-    import {
-        TooltipContent,
-        TooltipProvider,
-        Tooltip as TooltipRoot,
-        TooltipTrigger
-    } from '$lib/components/ui/tooltip';
     import { editorMouse } from '$lib/editor-mouse.svelte';
     import { editorState, PointerMode } from '$lib/editor-state.svelte';
     import { pianoRollMouse } from '$lib/piano-roll-mouse.svelte';
     import { pianoRollState } from '$lib/piano-roll-state.svelte';
-    import { INSTRUMENT_NAMES } from '$lib/types';
-    import type { Snippet } from 'svelte';
-    import MousePointer from '~icons/lucide/mouse-pointer';
-    import MousePointerClick from '~icons/lucide/mouse-pointer-click';
-    import Pause from '~icons/lucide/pause';
-    import Pencil from '~icons/lucide/pencil';
-    import Play from '~icons/lucide/play';
-    import Repeat from '~icons/lucide/repeat';
-    import SkipBack from '~icons/lucide/skip-back';
     import PlayheadCursor from '../playhead-cursor.svelte';
     import RulerShell from '../ruler-shell.svelte';
     import TimelineGrid from '../timeline-grid.svelte';
+    import PianoRollHeader from './piano-roll-header.svelte';
     import PianoRollMouseWindowEvents from './piano-roll-mouse-window-events.svelte';
 
     $effect(() => {
@@ -81,25 +66,6 @@
     });
 </script>
 
-{#snippet tooltipped({
-    label,
-    children,
-    disableCloseOnTriggerClick = false
-}: {
-    label: string;
-    children: Snippet<[{ props: any }]>;
-    disableCloseOnTriggerClick?: boolean;
-})}
-    <TooltipRoot {disableCloseOnTriggerClick}>
-        <TooltipTrigger>
-            {#snippet child({ props })}
-                {@render children?.({ props })}
-            {/snippet}
-        </TooltipTrigger>
-        <TooltipContent side="bottom">{label}</TooltipContent>
-    </TooltipRoot>
-{/snippet}
-
 {#snippet pianoRollRulerGutter()}
     <span class="text-xs font-medium tracking-wide text-muted-foreground uppercase">Keys</span>
 {/snippet}
@@ -113,154 +79,10 @@
     >
         {#if pianoRollState.sectionData}
             <div class="flex h-full flex-col">
-                <Sheet.Header class="border-b border-border/60 px-6 pt-6 pb-4">
-                    <Sheet.Title class="text-lg font-semibold"
-                        >{pianoRollState.sectionData.section.name}</Sheet.Title
-                    >
-                    <Sheet.Description class="text-sm text-muted-foreground">
-                        {INSTRUMENT_NAMES[pianoRollState.sectionData.channel.instrument]} • Channel {pianoRollState
-                            .sectionData.channelIndex + 1} •
-                        {pianoRollState.sectionBeatLength} beats
-                    </Sheet.Description>
-                </Sheet.Header>
-
-                <div
-                    class="flex h-12 items-center gap-3 border-b border-border bg-secondary/80 px-4 text-secondary-foreground"
-                >
-                    <TooltipProvider>
-                        <div class="flex flex-1 items-center gap-2">
-                            <div
-                                class="flex h-9 items-center gap-1.5 rounded-md bg-background/10 shadow-xs dark:bg-background/20"
-                            >
-                                {#snippet rewindButton({ props }: { props: any })}
-                                    <Button
-                                        {...props}
-                                        variant="ghost"
-                                        size="icon"
-                                        aria-label="Rewind to start"
-                                        onclick={pianoRollState.rewind}
-                                    >
-                                        <SkipBack class="size-5" />
-                                    </Button>
-                                {/snippet}
-                                {@render tooltipped({
-                                    label: 'Rewind to start',
-                                    children: rewindButton
-                                })}
-
-                                {#snippet playPauseButton({ props }: { props: any })}
-                                    <Button
-                                        {...props}
-                                        variant="ghost"
-                                        size="icon"
-                                        aria-label="Play/Pause"
-                                        onclick={pianoRollState.togglePlay}
-                                    >
-                                        {#if pianoRollState.isPlaying}
-                                            <Pause class="size-5" />
-                                        {:else}
-                                            <Play class="size-5" />
-                                        {/if}
-                                    </Button>
-                                {/snippet}
-                                {@render tooltipped({
-                                    label: pianoRollState.isPlaying ? 'Pause' : 'Play',
-                                    children: playPauseButton
-                                })}
-
-                                {#snippet loopButton({ props }: { props: any })}
-                                    <Button
-                                        {...props}
-                                        variant="ghost"
-                                        size="icon"
-                                        aria-label="Loop"
-                                        class={pianoRollState.loopModeButtonClass}
-                                        onclick={pianoRollState.cycleLoop}
-                                    >
-                                        <Repeat class="size-5" />
-                                    </Button>
-                                {/snippet}
-                                {@render tooltipped({
-                                    label: pianoRollState.loopModeLabel,
-                                    children: loopButton,
-                                    disableCloseOnTriggerClick: true
-                                })}
-                            </div>
-
-                            <div
-                                class="flex h-9 items-center rounded-md bg-background/20 px-3 font-mono text-sm tracking-widest tabular-nums shadow-xs select-none"
-                            >
-                                {pianoRollState.positionBar}:{pianoRollState.positionBeat}:{pianoRollState.positionTickInBeat}
-                            </div>
-                        </div>
-
-                        <div
-                            class="flex h-9 items-center gap-1.5 rounded-md bg-background/10 shadow-xs dark:bg-background/20"
-                        >
-                            {#snippet normalModeButton({ props }: { props: any })}
-                                <Button
-                                    {...props}
-                                    variant="ghost"
-                                    size="icon"
-                                    aria-label="Normal Mode"
-                                    class={pianoRollState.pointerButtonClass(PointerMode.Normal)}
-                                    onclick={() =>
-                                        pianoRollState.setPointerMode(PointerMode.Normal)}
-                                >
-                                    <MousePointer class="size-5" />
-                                </Button>
-                            {/snippet}
-                            {@render tooltipped({
-                                label: 'Normal Mode',
-                                children: normalModeButton,
-                                disableCloseOnTriggerClick: true
-                            })}
-
-                            {#snippet penModeButton({ props }: { props: any })}
-                                <Button
-                                    {...props}
-                                    variant="ghost"
-                                    size="icon"
-                                    aria-label="Pen Mode"
-                                    class={pianoRollState.pointerButtonClass('pen')}
-                                    onclick={() => pianoRollState.setPointerMode('pen')}
-                                >
-                                    <Pencil class="size-5" />
-                                </Button>
-                            {/snippet}
-                            {@render tooltipped({
-                                label: 'Pen Mode',
-                                children: penModeButton,
-                                disableCloseOnTriggerClick: true
-                            })}
-
-                            {#snippet autoScrollButton({ props }: { props: any })}
-                                <Button
-                                    {...props}
-                                    variant="ghost"
-                                    size="icon"
-                                    aria-label="Follow Playhead"
-                                    onclick={() =>
-                                        editorState.setAutoScrollEnabled(
-                                            !editorState.autoScrollEnabled
-                                        )}
-                                    class={editorState.autoScrollEnabled
-                                        ? 'bg-primary text-primary-foreground hover:bg-primary/90 hover:text-primary-foreground dark:hover:bg-primary/90'
-                                        : ''}
-                                >
-                                    <MousePointerClick class="size-5" />
-                                </Button>
-                            {/snippet}
-                            {@render tooltipped({
-                                label: editorState.autoScrollEnabled
-                                    ? 'Follow Playhead: On'
-                                    : 'Follow Playhead: Off',
-                                children: autoScrollButton,
-                                disableCloseOnTriggerClick: true
-                            })}
-                        </div>
-                    </TooltipProvider>
-                </div>
+                <PianoRollHeader
+                    sectionData={pianoRollState.sectionData}
+                    sectionBeatLength={pianoRollState.sectionBeatLength}
+                />
 
                 <div class="flex flex-1 flex-col overflow-hidden">
                     <RulerShell

--- a/src/lib/components/editor/note-channel/note-piano-roll.svelte
+++ b/src/lib/components/editor/note-channel/note-piano-roll.svelte
@@ -7,11 +7,11 @@
         Tooltip as TooltipRoot,
         TooltipTrigger
     } from '$lib/components/ui/tooltip';
-    import { editorState, PointerMode } from '$lib/editor-state.svelte';
     import { editorMouse } from '$lib/editor-mouse.svelte';
-    import { LoopMode, player } from '$lib/playback.svelte';
-    import { pianoRollMouse, type KeyRange, type PianoRollPointerMode } from '$lib/piano-roll-mouse.svelte';
-    import { INSTRUMENT_NAMES, type Note, type NoteChannel, type NoteSection } from '$lib/types';
+    import { editorState, PointerMode } from '$lib/editor-state.svelte';
+    import { pianoRollMouse } from '$lib/piano-roll-mouse.svelte';
+    import { pianoRollState } from '$lib/piano-roll-state.svelte';
+    import { INSTRUMENT_NAMES } from '$lib/types';
     import type { Snippet } from 'svelte';
     import MousePointer from '~icons/lucide/mouse-pointer';
     import MousePointerClick from '~icons/lucide/mouse-pointer-click';
@@ -20,294 +20,10 @@
     import Play from '~icons/lucide/play';
     import Repeat from '~icons/lucide/repeat';
     import SkipBack from '~icons/lucide/skip-back';
-    import PianoRollMouseWindowEvents from './piano-roll-mouse-window-events.svelte';
     import PlayheadCursor from '../playhead-cursor.svelte';
-    import TimelineGrid from '../timeline-grid.svelte';
     import RulerShell from '../ruler-shell.svelte';
-
-    type PianoRollContext = {
-        channel: NoteChannel;
-        section: NoteSection;
-        channelIndex: number;
-        sectionIndex: number;
-    };
-
-    const pianoRollTarget = $derived(editorState.pianoRollTarget);
-
-    let sheetOpen = $state(false);
-
-    $effect(() => {
-        sheetOpen = pianoRollTarget !== null;
-    });
-
-    $effect(() => {
-        if (!sheetOpen && pianoRollTarget) {
-            editorState.closePianoRoll();
-        }
-    });
-
-    $effect(() => {
-        if (pianoRollTarget && !sectionData) {
-            editorState.closePianoRoll();
-            sheetOpen = false;
-        }
-    });
-
-    const sectionData = $derived.by<PianoRollContext | null>(() => {
-        const target = pianoRollTarget;
-        if (!target) return null;
-        const channel = player.song?.channels?.[target.channelIndex];
-        if (!channel || channel.kind !== 'note') return null;
-        const section = channel.sections?.[target.sectionIndex];
-        if (!section) return null;
-        return {
-            channel,
-            section,
-            channelIndex: target.channelIndex,
-            sectionIndex: target.sectionIndex
-        };
-    });
-
-    const ticksPerBeat = $derived(Math.max(1, editorState.ticksPerBeat));
-    const beatsPerBar = $derived(Math.max(1, editorState.beatsPerBar));
-    const pxPerTick = $derived(
-        editorState.ticksPerBeat > 0 ? editorState.pxPerBeat / editorState.ticksPerBeat : 0
-    );
-
-    const DEFAULT_KEY_RANGE: KeyRange = { min: 33, max: 57 };
-
-    function computeKeyRange(notes: Note[] | undefined): KeyRange {
-        if (!notes || notes.length === 0) return DEFAULT_KEY_RANGE;
-        let min = Math.min(...notes.map((n) => n.key));
-        let max = Math.max(...notes.map((n) => n.key));
-        min = Math.max(0, min - 2);
-        max = Math.min(87, max + 2);
-        if (max - min < 12) {
-            const pad = Math.ceil((12 - (max - min)) / 2);
-            min = Math.max(0, min - pad);
-            max = Math.min(87, max + pad);
-        }
-        return { min, max };
-    }
-
-    const keyRange = $derived.by<KeyRange>(() => computeKeyRange(sectionData?.section?.notes));
-    const keyHeight = 20;
-    const keyCount = $derived.by(() => keyRange.max - keyRange.min + 1);
-    const gridHeight = $derived(Math.max(1, keyCount) * keyHeight);
-
-    const NOTE_SPAN = 1;
-    const noteLaneHeight = Math.max(8, keyHeight - 6);
-
-    let gridScroller = $state<HTMLDivElement | null>(null);
-    let keysScroller = $state<HTMLDivElement | null>(null);
-    let gridScrollLeft = $state(0);
-    let gridContent = $state<HTMLDivElement | null>(null);
-
-    function handleGridScroll() {
-        const grid = gridScroller;
-        const keys = keysScroller;
-        if (!grid) return;
-        const { scrollTop, scrollLeft } = grid;
-        gridScrollLeft = scrollLeft;
-        if (keys && Math.abs(keys.scrollTop - scrollTop) > 1) {
-            keys.scrollTop = scrollTop;
-        }
-    }
-
-    $effect(() => {
-        const grid = gridScroller;
-        if (!grid) return;
-        if (Math.abs(grid.scrollLeft - gridScrollLeft) > 1) {
-            grid.scrollLeft = gridScrollLeft;
-        }
-    });
-
-    $effect(() => {
-        pianoRollMouse.setGridContent(gridContent);
-    });
-
-    $effect(() => {
-        pianoRollMouse.setSection(sectionData?.section ?? null);
-    });
-
-    $effect(() => {
-        pianoRollMouse.updateGeometry({
-            pxPerTick: pxPerTick > 0 ? pxPerTick : 1,
-            keyRange,
-            keyHeight
-        });
-    });
-
-    $effect(() => {
-        pianoRollMouse.setActive(sheetOpen);
-    });
-
-    $effect(() => {
-        pianoRollMouse.setPointerMode(pointerMode);
-    });
-
-    function keyNumberToInfo(key: number) {
-        const names = ['A', 'A#', 'B', 'C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#'];
-        const noteName = names[key % 12];
-        const octave = Math.floor((key + 9) / 12);
-        const isBlack = noteName.includes('#');
-        return { label: `${noteName}${octave}`, isBlack };
-    }
-
-    const keyRows = $derived.by<Array<{ key: number; label: string; isBlack: boolean }>>(() => {
-        const rows: Array<{ key: number; label: string; isBlack: boolean }> = [];
-        for (let key = keyRange.max; key >= keyRange.min; key--) {
-            const info = keyNumberToInfo(key);
-            rows.push({ key, ...info });
-        }
-        return rows;
-    });
-
-    const rawGridWidth = $derived.by(() => {
-        const section = sectionData?.section;
-        if (!section) return 0;
-        const pxTick = pxPerTick > 0 ? pxPerTick : 1;
-        const lengthPx = section.length * pxTick;
-        const minWidth = Math.max(640, beatsPerBar * ticksPerBeat * pxTick);
-        return Math.max(minWidth, Math.ceil(lengthPx));
-    });
-
-    const barWidth = $derived(Math.max(1, editorState.barWidth));
-    const totalBars = $derived.by(() => {
-        if (barWidth <= 0) return 1;
-        return Math.max(1, Math.ceil(rawGridWidth / barWidth));
-    });
-    const contentWidth = $derived(totalBars * barWidth);
-
-    const notesToRender = $derived.by<
-        Array<{
-            id: string;
-            left: number;
-            top: number;
-            width: number;
-            height: number;
-            note: Note;
-            selected: boolean;
-        }>
-    >(() => {
-        const section = sectionData?.section;
-        if (!section)
-            return [] as Array<{
-                id: string;
-                left: number;
-                top: number;
-                width: number;
-                height: number;
-                note: Note;
-                selected: boolean;
-            }>;
-
-        const range = keyRange;
-        const pxTickValue = pxPerTick > 0 ? pxPerTick : 1;
-        const laneHeight = noteLaneHeight;
-        const offset = (keyHeight - laneHeight) / 2;
-        const selectedSet = new Set(pianoRollMouse.selectedNotes);
-
-        return (section.notes ?? []).map((note, index) => {
-            const top = (range.max - note.key) * keyHeight + offset;
-            const width = Math.max(8, Math.round(NOTE_SPAN * pxTickValue));
-            const left = Math.max(0, Math.round(note.tick * pxTickValue));
-            const id = `${section.startingTick + note.tick}:${note.key}:${index}`;
-            return {
-                id,
-                left,
-                top,
-                width,
-                height: laneHeight,
-                note,
-                selected: selectedSet.has(note)
-            };
-        });
-    });
-
-    const sectionBeatLength = $derived.by(() => {
-        const section = sectionData?.section;
-        if (!section) return 0;
-        return +(section.length / ticksPerBeat).toFixed(2);
-    });
-
-    const sectionStartTick = $derived(sectionData?.section?.startingTick ?? 0);
-    const sectionEndTick = $derived.by(
-        () => sectionStartTick + (sectionData?.section?.length ?? 0)
-    );
-    const cursorTick = $derived(player.currentTick);
-    const cursorVisible = $derived.by(
-        () => cursorTick >= sectionStartTick && cursorTick <= sectionEndTick
-    );
-
-    $effect(() => {
-        gridScrollLeft = gridScroller?.scrollLeft ?? 0;
-    });
-
-    const rewind = () => player.setBarBeat(0, 0);
-    const togglePlay = () => (player.isPlaying ? player.pause() : player.resume());
-    const cycleLoop = () => {
-        switch (player.loopMode) {
-            case LoopMode.Off:
-                player.setLoopMode(LoopMode.Song);
-                break;
-            case LoopMode.Song:
-                player.setLoopMode(LoopMode.Selection);
-                break;
-            case LoopMode.Selection:
-            default:
-                player.setLoopMode(LoopMode.Off);
-                break;
-        }
-    };
-
-    const positionBar = $derived(String(player.currentBar + 1).padStart(3, '0'));
-    const positionBeat = $derived(String(player.currentBeat + 1).padStart(2, '0'));
-    const positionTickInBeat = $derived(
-        String((player.currentTick % player.ticksPerBeat) + 1).padStart(2, '0')
-    );
-
-    const loopModeButtonClass = $derived.by(() => {
-        switch (player.loopMode) {
-            case LoopMode.Selection:
-                return 'bg-purple-600 text-white hover:bg-purple-600/80 dark:hover:bg-purple-600/80 hover:text-white';
-            case LoopMode.Song:
-                return 'bg-amber-500 text-white hover:bg-amber-500/80 dark:hover:bg-amber-500/80 hover:text-white';
-            case LoopMode.Off:
-            default:
-                return '';
-        }
-    });
-
-    const loopModeLabel = $derived.by(() => {
-        switch (player.loopMode) {
-            case LoopMode.Selection:
-                return 'Loop: Selection';
-            case LoopMode.Song:
-                return 'Loop: Song';
-            case LoopMode.Off:
-            default:
-                return 'Loop: Off';
-        }
-    });
-
-    let pointerMode = $state<PianoRollPointerMode>(PointerMode.Normal);
-
-    const setPointerMode = (mode: PianoRollPointerMode) => {
-        pointerMode = mode;
-        pianoRollMouse.setPointerMode(mode);
-    };
-
-    $effect(() => {
-        if (!sheetOpen) {
-            pointerMode = PointerMode.Normal;
-        }
-    });
-
-    const pointerButtonClass = (mode: PianoRollPointerMode) =>
-        pointerMode === mode
-            ? 'bg-indigo-600 text-white hover:bg-indigo-600/80 dark:hover:bg-indigo-600/80 hover:text-white'
-            : '';
+    import TimelineGrid from '../timeline-grid.svelte';
+    import PianoRollMouseWindowEvents from './piano-roll-mouse-window-events.svelte';
 </script>
 
 {#snippet tooltipped({
@@ -330,26 +46,26 @@
 {/snippet}
 
 {#snippet pianoRollRulerGutter()}
-    <span class="text-xs font-medium uppercase tracking-wide text-muted-foreground">Keys</span>
+    <span class="text-xs font-medium tracking-wide text-muted-foreground uppercase">Keys</span>
 {/snippet}
 
 <PianoRollMouseWindowEvents />
 
-<Sheet.Root bind:open={sheetOpen}>
+<Sheet.Root bind:open={pianoRollState.sheetOpen}>
     <Sheet.Content
         side="bottom"
         class="h-[70vh] w-full max-w-none border-t border-border bg-background"
     >
-        {#if sectionData}
+        {#if pianoRollState.sectionData}
             <div class="flex h-full flex-col">
                 <Sheet.Header class="border-b border-border/60 px-6 pt-6 pb-4">
                     <Sheet.Title class="text-lg font-semibold"
-                        >{sectionData.section.name}</Sheet.Title
+                        >{pianoRollState.sectionData.section.name}</Sheet.Title
                     >
                     <Sheet.Description class="text-sm text-muted-foreground">
-                        {INSTRUMENT_NAMES[sectionData.channel.instrument]} • Channel {sectionData.channelIndex +
-                            1} •
-                        {sectionBeatLength} beats
+                        {INSTRUMENT_NAMES[pianoRollState.sectionData.channel.instrument]} • Channel {pianoRollState
+                            .sectionData.channelIndex + 1} •
+                        {pianoRollState.sectionBeatLength} beats
                     </Sheet.Description>
                 </Sheet.Header>
 
@@ -367,7 +83,7 @@
                                         variant="ghost"
                                         size="icon"
                                         aria-label="Rewind to start"
-                                        onclick={rewind}
+                                        onclick={pianoRollState.rewind}
                                     >
                                         <SkipBack class="size-5" />
                                     </Button>
@@ -383,9 +99,9 @@
                                         variant="ghost"
                                         size="icon"
                                         aria-label="Play/Pause"
-                                        onclick={togglePlay}
+                                        onclick={pianoRollState.togglePlay}
                                     >
-                                        {#if player.isPlaying}
+                                        {#if pianoRollState.isPlaying}
                                             <Pause class="size-5" />
                                         {:else}
                                             <Play class="size-5" />
@@ -393,7 +109,7 @@
                                     </Button>
                                 {/snippet}
                                 {@render tooltipped({
-                                    label: player.isPlaying ? 'Pause' : 'Play',
+                                    label: pianoRollState.isPlaying ? 'Pause' : 'Play',
                                     children: playPauseButton
                                 })}
 
@@ -403,14 +119,14 @@
                                         variant="ghost"
                                         size="icon"
                                         aria-label="Loop"
-                                        class={loopModeButtonClass}
-                                        onclick={cycleLoop}
+                                        class={pianoRollState.loopModeButtonClass}
+                                        onclick={pianoRollState.cycleLoop}
                                     >
                                         <Repeat class="size-5" />
                                     </Button>
                                 {/snippet}
                                 {@render tooltipped({
-                                    label: loopModeLabel,
+                                    label: pianoRollState.loopModeLabel,
                                     children: loopButton,
                                     disableCloseOnTriggerClick: true
                                 })}
@@ -419,7 +135,7 @@
                             <div
                                 class="flex h-9 items-center rounded-md bg-background/20 px-3 font-mono text-sm tracking-widest tabular-nums shadow-xs select-none"
                             >
-                                {positionBar}:{positionBeat}:{positionTickInBeat}
+                                {pianoRollState.positionBar}:{pianoRollState.positionBeat}:{pianoRollState.positionTickInBeat}
                             </div>
                         </div>
 
@@ -432,8 +148,9 @@
                                     variant="ghost"
                                     size="icon"
                                     aria-label="Normal Mode"
-                                    class={pointerButtonClass(PointerMode.Normal)}
-                                    onclick={() => setPointerMode(PointerMode.Normal)}
+                                    class={pianoRollState.pointerButtonClass(PointerMode.Normal)}
+                                    onclick={() =>
+                                        pianoRollState.setPointerMode(PointerMode.Normal)}
                                 >
                                     <MousePointer class="size-5" />
                                 </Button>
@@ -450,8 +167,8 @@
                                     variant="ghost"
                                     size="icon"
                                     aria-label="Pen Mode"
-                                    class={pointerButtonClass('pen')}
-                                    onclick={() => setPointerMode('pen')}
+                                    class={pianoRollState.pointerButtonClass('pen')}
+                                    onclick={() => pianoRollState.setPointerMode('pen')}
                                 >
                                     <Pencil class="size-5" />
                                 </Button>
@@ -494,28 +211,22 @@
                     <RulerShell
                         class="items-center border-b border-border bg-secondary/40 text-sm"
                         gutterWidth={96}
-                        contentWidth={contentWidth}
-                        scrollLeft={gridScrollLeft}
+                        contentWidth={pianoRollState.contentWidth}
+                        scrollLeft={pianoRollState.gridScrollLeft}
                         pointerDownHandler={(container, event) =>
                             editorMouse.handleRulerPointerDown(container, event)}
                         gutter={pianoRollRulerGutter}
-                        on:scrollLeftChange={(event) => {
-                            const left = event.detail;
-                            const grid = gridScroller;
-                            if (grid && Math.abs(grid.scrollLeft - left) > 1) {
-                                grid.scrollLeft = left;
-                            }
-                            gridScrollLeft = left;
-                        }}
+                        on:scrollLeftChange={(event) =>
+                            pianoRollState.handleRulerScrollLeft(event.detail)}
                     >
                         <TimelineGrid
                             class="z-0"
                             gutterWidth={0}
-                            contentWidth={contentWidth}
-                            scrollLeft={gridScrollLeft}
-                            {barWidth}
-                            {totalBars}
-                            {beatsPerBar}
+                            contentWidth={pianoRollState.contentWidth}
+                            scrollLeft={0}
+                            barWidth={pianoRollState.barWidth}
+                            totalBars={pianoRollState.totalBars}
+                            beatsPerBar={pianoRollState.beatsPerBar}
                             pxPerBeat={editorState.pxPerBeat}
                             showLabels
                         />
@@ -525,19 +236,22 @@
                         <div class="flex w-24 flex-col border-r border-border/50 bg-muted/40">
                             <div
                                 class="scrollbar-fade flex-1 overflow-auto"
-                                bind:this={keysScroller}
+                                bind:this={pianoRollState.keysScroller}
                                 onwheel={(event) => {
-                                    const grid = gridScroller;
+                                    const grid = pianoRollState.gridScroller;
                                     if (!grid) return;
                                     grid.scrollBy({ left: event.deltaX, top: event.deltaY });
                                     event.preventDefault();
                                 }}
                             >
-                                <div class="flex flex-col" style={`height:${gridHeight}px;`}>
-                                    {#each keyRows as row, index}
+                                <div
+                                    class="flex flex-col"
+                                    style={`height:${pianoRollState.gridHeight}px;`}
+                                >
+                                    {#each pianoRollState.keyRows as row, index}
                                         <div
-                                            class={`flex items-center justify-end pr-3 text-xs ${row.isBlack ? 'bg-muted/70 text-muted-foreground' : 'bg-background'} ${index === keyRows.length - 1 ? '' : 'border-b border-border/30'}`}
-                                            style={`height:${keyHeight}px;`}
+                                            class={`flex items-center justify-end pr-3 text-xs ${row.isBlack ? 'bg-muted/70 text-muted-foreground' : 'bg-background'} ${index === pianoRollState.keyRows.length - 1 ? '' : 'border-b border-border/30'}`}
+                                            style={`height:${pianoRollState.keyHeight}px;`}
                                         >
                                             {row.label}
                                         </div>
@@ -549,74 +263,90 @@
                         <div class="relative flex-1 overflow-hidden bg-muted/20">
                             <div
                                 class="relative h-full w-full overflow-auto"
-                                bind:this={gridScroller}
-                                onscroll={handleGridScroll}
+                                bind:this={pianoRollState.gridScroller}
+                                onscroll={pianoRollState.handleGridScroll}
                             >
                                 <div
-                                    bind:this={gridContent}
+                                    bind:this={pianoRollState.gridContent}
                                     class="relative"
-                                    style={`width:${contentWidth}px; height:${gridHeight}px;`}
+                                    style={`width:${pianoRollState.contentWidth}px; height:${pianoRollState.gridHeight}px;`}
                                     onpointerdown={pianoRollMouse.handleBackgroundPointerDown}
                                 >
-                                <TimelineGrid
-                                    gutterWidth={0}
-                                    class="z-10"
-                                    {contentWidth}
-                                    scrollLeft={0}
-                                    {barWidth}
-                                    {totalBars}
-                                    {beatsPerBar}
-                                    pxPerBeat={editorState.pxPerBeat}
-                                />
+                                    <TimelineGrid
+                                        gutterWidth={0}
+                                        class="z-10"
+                                        contentWidth={pianoRollState.contentWidth}
+                                        scrollLeft={0}
+                                        barWidth={pianoRollState.barWidth}
+                                        totalBars={pianoRollState.totalBars}
+                                        beatsPerBar={pianoRollState.beatsPerBar}
+                                        pxPerBeat={editorState.pxPerBeat}
+                                    />
 
-                                {#each keyRows as row, index}
-                                    <div
-                                        class={`${row.isBlack ? 'bg-muted/60' : 'bg-background'} absolute right-0 left-0 ${index === keyRows.length - 1 ? '' : 'border-b border-border/30'}`}
-                                        style={`top:${index * keyHeight}px; height:${keyHeight}px;`}
-                                    ></div>
-                                {/each}
+                                    {#each pianoRollState.keyRows as row, index}
+                                        <div
+                                            class={`${row.isBlack ? 'bg-muted/60' : 'bg-background'} absolute right-0 left-0 ${index === pianoRollState.keyRows.length - 1 ? '' : 'border-b border-border/30'}`}
+                                            style={`top:${index * pianoRollState.keyHeight}px; height:${pianoRollState.keyHeight}px;`}
+                                        ></div>
+                                    {/each}
 
-                                {#each notesToRender as note}
-                                    <div
-                                        data-note-id={`${sectionStartTick + note.note.tick}:${note.note.key}:${sectionData?.channel.instrument ?? 'note'}`}
-                                        class={`absolute z-30 rounded-sm border ${
-                                            note.selected
-                                                ? 'border-white/70 bg-primary text-primary-foreground shadow-lg'
-                                                : 'border-primary/30 bg-primary/80 shadow-sm'
-                                        }`}
-                                        style={`left:${note.left}px; top:${note.top}px; width:${note.width}px; height:${note.height}px;`}
-                                        onpointerdown={(event) =>
-                                            pianoRollMouse.handleNotePointerDown(note.note, event)}
-                                    ></div>
-                                {/each}
+                                    {#each pianoRollState.notesToRender as note}
+                                        <div
+                                            data-note-id={`${pianoRollState.sectionStartTick + note.note.tick}:${note.note.key}:${pianoRollState.sectionData?.channel.instrument ?? 'note'}`}
+                                            class={`absolute z-30 rounded-sm border ${
+                                                note.selected
+                                                    ? 'border-white/70 bg-primary text-primary-foreground shadow-lg'
+                                                    : 'border-primary/30 bg-primary/80 shadow-sm'
+                                            }`}
+                                            style={`left:${note.left}px; top:${note.top}px; width:${note.width}px; height:${note.height}px;`}
+                                            onpointerdown={(event) =>
+                                                pianoRollMouse.handleNotePointerDown(
+                                                    note.note,
+                                                    event
+                                                )}
+                                        ></div>
+                                    {/each}
 
-                                {#if pianoRollMouse.selectionBox}
-                                    {@const box = pianoRollMouse.selectionBox}
-                                    {@const px = pxPerTick > 0 ? pxPerTick : 1}
-                                    {@const tickStart = Math.min(box.startTick, box.currentTick)}
-                                    {@const tickEnd = Math.max(box.startTick, box.currentTick) + 1}
-                                    {@const keyTop = Math.max(box.startKey, box.currentKey)}
-                                    {@const keyBottom = Math.min(box.startKey, box.currentKey)}
-                                    {@const left = Math.round(tickStart * px)}
-                                    {@const right = Math.round(tickEnd * px)}
-                                    {@const top = (keyRange.max - keyTop) * keyHeight}
-                                    {@const bottom = (keyRange.max - keyBottom + 1) * keyHeight}
-                                    <div
-                                        class="pointer-events-none absolute z-20 border-2 border-indigo-400/70 bg-indigo-500/10"
-                                        style={`left:${Math.min(left, right)}px; top:${Math.min(top, bottom)}px; width:${Math.max(1, Math.abs(right - left))}px; height:${Math.max(1, Math.abs(bottom - top))}px;`}
-                                    ></div>
-                                {/if}
+                                    {#if pianoRollMouse.selectionBox}
+                                        {@const box = pianoRollMouse.selectionBox}
+                                        {@const px =
+                                            pianoRollState.pxPerTick > 0
+                                                ? pianoRollState.pxPerTick
+                                                : 1}
+                                        {@const tickStart = Math.min(
+                                            box.startTick,
+                                            box.currentTick
+                                        )}
+                                        {@const tickEnd =
+                                            Math.max(box.startTick, box.currentTick) + 1}
+                                        {@const keyTop = Math.max(box.startKey, box.currentKey)}
+                                        {@const keyBottom = Math.min(box.startKey, box.currentKey)}
+                                        {@const left = Math.round(tickStart * px)}
+                                        {@const right = Math.round(tickEnd * px)}
+                                        {@const top =
+                                            (pianoRollState.keyRange.max - keyTop) *
+                                            pianoRollState.keyHeight}
+                                        {@const bottom =
+                                            (pianoRollState.keyRange.max - keyBottom + 1) *
+                                            pianoRollState.keyHeight}
+                                        <div
+                                            class="pointer-events-none absolute z-20 border-2 border-indigo-400/70 bg-indigo-500/10"
+                                            style={`left:${Math.min(left, right)}px; top:${Math.min(top, bottom)}px; width:${Math.max(1, Math.abs(right - left))}px; height:${Math.max(1, Math.abs(bottom - top))}px;`}
+                                        ></div>
+                                    {/if}
+                                </div>
                             </div>
-                        </div>
-                        <PlayheadCursor
-                            gutterWidth={0}
-                            class="z-40"
-                            scrollLeft={gridScrollLeft}
-                            pxPerTick={pxPerTick > 0 ? pxPerTick : 1}
-                            currentTick={cursorTick}
-                            tickOffset={sectionStartTick}
-                            visible={cursorVisible}
-                        />
+                            <PlayheadCursor
+                                gutterWidth={0}
+                                class="z-40"
+                                scrollLeft={pianoRollState.gridScrollLeft}
+                                pxPerTick={pianoRollState.pxPerTick > 0
+                                    ? pianoRollState.pxPerTick
+                                    : 1}
+                                currentTick={pianoRollState.cursorTick}
+                                tickOffset={pianoRollState.sectionStartTick}
+                                visible={pianoRollState.cursorVisible}
+                            />
                         </div>
                     </div>
                 </div>

--- a/src/lib/components/editor/note-channel/note-piano-roll.svelte
+++ b/src/lib/components/editor/note-channel/note-piano-roll.svelte
@@ -1,0 +1,300 @@
+<script lang="ts">
+    import * as Sheet from '$lib/components/ui/sheet';
+    import { editorState } from '$lib/editor-state.svelte';
+    import { player } from '$lib/playback.svelte';
+    import { INSTRUMENT_NAMES, type Note, type NoteChannel, type NoteSection } from '$lib/types';
+    import PlayheadCursor from '../playhead-cursor.svelte';
+    import TimelineGrid from '../timeline-grid.svelte';
+
+    type PianoRollContext = {
+        channel: NoteChannel;
+        section: NoteSection;
+        channelIndex: number;
+        sectionIndex: number;
+    };
+
+    type KeyRange = { min: number; max: number };
+
+    const pianoRollTarget = $derived(editorState.pianoRollTarget);
+
+    let sheetOpen = $state(false);
+
+    $effect(() => {
+        sheetOpen = pianoRollTarget !== null;
+    });
+
+    $effect(() => {
+        if (!sheetOpen && pianoRollTarget) {
+            editorState.closePianoRoll();
+        }
+    });
+
+    $effect(() => {
+        if (pianoRollTarget && !sectionData) {
+            editorState.closePianoRoll();
+            sheetOpen = false;
+        }
+    });
+
+    const sectionData = $derived.by<PianoRollContext | null>(() => {
+        const target = pianoRollTarget;
+        if (!target) return null;
+        const channel = player.song?.channels?.[target.channelIndex];
+        if (!channel || channel.kind !== 'note') return null;
+        const section = channel.sections?.[target.sectionIndex];
+        if (!section) return null;
+        return { channel, section, channelIndex: target.channelIndex, sectionIndex: target.sectionIndex };
+    });
+
+    const ticksPerBeat = $derived(Math.max(1, editorState.ticksPerBeat));
+    const beatsPerBar = $derived(Math.max(1, editorState.beatsPerBar));
+    const pxPerTick = $derived(
+        editorState.ticksPerBeat > 0 ? editorState.pxPerBeat / editorState.ticksPerBeat : 0
+    );
+
+    const DEFAULT_KEY_RANGE: KeyRange = { min: 33, max: 57 };
+
+    function computeKeyRange(notes: Note[] | undefined): KeyRange {
+        if (!notes || notes.length === 0) return DEFAULT_KEY_RANGE;
+        let min = Math.min(...notes.map((n) => n.key));
+        let max = Math.max(...notes.map((n) => n.key));
+        min = Math.max(0, min - 2);
+        max = Math.min(87, max + 2);
+        if (max - min < 12) {
+            const pad = Math.ceil((12 - (max - min)) / 2);
+            min = Math.max(0, min - pad);
+            max = Math.min(87, max + pad);
+        }
+        return { min, max };
+    }
+
+    const keyRange = $derived.by<KeyRange>(() => computeKeyRange(sectionData?.section?.notes));
+    const keyHeight = 20;
+    const keyCount = $derived.by(() => keyRange.max - keyRange.min + 1);
+    const gridHeight = $derived(Math.max(1, keyCount) * keyHeight);
+
+    const noteLaneHeight = Math.max(8, keyHeight - 6);
+
+    let gridScroller = $state<HTMLDivElement | null>(null);
+    let keysScroller = $state<HTMLDivElement | null>(null);
+    let gridScrollLeft = $state(0);
+
+    function handleGridScroll() {
+        const grid = gridScroller;
+        const keys = keysScroller;
+        if (!grid) return;
+        const { scrollTop, scrollLeft } = grid;
+        gridScrollLeft = scrollLeft;
+        if (keys && Math.abs(keys.scrollTop - scrollTop) > 1) {
+            keys.scrollTop = scrollTop;
+        }
+    }
+
+    function keyNumberToInfo(key: number) {
+        const names = ['A', 'A#', 'B', 'C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#'];
+        const noteName = names[key % 12];
+        const octave = Math.floor((key + 9) / 12);
+        const isBlack = noteName.includes('#');
+        return { label: `${noteName}${octave}`, isBlack };
+    }
+
+    const keyRows = $derived.by<Array<{ key: number; label: string; isBlack: boolean }>>(() => {
+        const rows: Array<{ key: number; label: string; isBlack: boolean }> = [];
+        for (let key = keyRange.max; key >= keyRange.min; key--) {
+            const info = keyNumberToInfo(key);
+            rows.push({ key, ...info });
+        }
+        return rows;
+    });
+
+    const rawGridWidth = $derived.by(() => {
+        const section = sectionData?.section;
+        if (!section) return 0;
+        const pxTick = pxPerTick > 0 ? pxPerTick : 1;
+        const lengthPx = section.length * pxTick;
+        const minWidth = Math.max(640, beatsPerBar * ticksPerBeat * pxTick);
+        return Math.max(minWidth, Math.ceil(lengthPx));
+    });
+
+    const barWidth = $derived(Math.max(1, editorState.barWidth));
+    const totalBars = $derived.by(() => {
+        if (barWidth <= 0) return 1;
+        return Math.max(1, Math.ceil(rawGridWidth / barWidth));
+    });
+    const contentWidth = $derived(totalBars * barWidth);
+
+    const beatMarkers = $derived.by<Array<{ left: number; index: number; isBar: boolean }>>(() => {
+        const pxPerBeatValue = Math.max(1, editorState.pxPerBeat);
+        const totalBeats = Math.ceil(contentWidth / pxPerBeatValue);
+        const markers: Array<{ left: number; index: number; isBar: boolean }> = [];
+        for (let beat = 0; beat <= totalBeats; beat++) {
+            const left = beat * pxPerBeatValue;
+            markers.push({ left, index: beat, isBar: beat % beatsPerBar === 0 });
+        }
+        return markers;
+    });
+
+    const notesToRender = $derived.by<
+        Array<{ id: string; left: number; top: number; width: number; height: number }>
+    >(() => {
+        const section = sectionData?.section;
+        if (!section) return [] as Array<{ id: string; left: number; top: number; width: number; height: number }>;
+        const range = keyRange;
+        const pxTick = pxPerTick > 0 ? pxPerTick : 1;
+        const laneHeight = noteLaneHeight;
+        const offset = (keyHeight - laneHeight) / 2;
+        return (section.notes ?? []).map((note) => {
+            const top = (range.max - note.key) * keyHeight + offset;
+            const width = Math.max(8, Math.round(pxTick * 2));
+            const left = Math.max(0, Math.round(note.tick * pxTick));
+            return {
+                id: `${section.startingTick + note.tick}:${note.key}`,
+                left,
+                top,
+                width,
+                height: laneHeight
+            };
+        });
+    });
+
+    const sectionBeatLength = $derived.by(() => {
+        const section = sectionData?.section;
+        if (!section) return 0;
+        return +(section.length / ticksPerBeat).toFixed(2);
+    });
+
+    const sectionStartTick = $derived(sectionData?.section?.startingTick ?? 0);
+    const sectionEndTick = $derived(() => sectionStartTick + (sectionData?.section?.length ?? 0));
+    const cursorTick = $derived(player.currentTick);
+    const cursorVisible = $derived(() => cursorTick >= sectionStartTick && cursorTick <= sectionEndTick);
+
+    $effect(() => {
+        gridScrollLeft = gridScroller?.scrollLeft ?? 0;
+    });
+</script>
+
+<Sheet.Root bind:open={sheetOpen}>
+    <Sheet.Content
+        side="bottom"
+        class="h-[70vh] w-full max-w-none border-t border-border bg-background"
+    >
+        {#if sectionData}
+            <div class="flex h-full flex-col">
+                <Sheet.Header class="border-b border-border/60 px-6 pb-4 pt-6">
+                    <Sheet.Title class="text-lg font-semibold">{sectionData.section.name}</Sheet.Title>
+                    <Sheet.Description class="text-sm text-muted-foreground">
+                        {INSTRUMENT_NAMES[sectionData.channel.instrument]} • Channel {sectionData.channelIndex + 1} •
+                        {sectionBeatLength} beats
+                    </Sheet.Description>
+                </Sheet.Header>
+
+                <div class="flex flex-1 overflow-hidden">
+                    <div class="flex w-24 flex-col border-r border-border/50 bg-muted/40">
+                        <div class="flex h-10 items-center border-b border-border/40 px-3 text-xs uppercase tracking-wide text-muted-foreground">
+                            Keys
+                        </div>
+                        <div
+                            class="scrollbar-fade flex-1 overflow-auto"
+                            bind:this={keysScroller}
+                            onwheel={(event) => {
+                                const grid = gridScroller;
+                                if (!grid) return;
+                                grid.scrollBy({ left: event.deltaX, top: event.deltaY });
+                                event.preventDefault();
+                            }}
+                        >
+                            <div class="flex flex-col" style={`height:${gridHeight}px;`}>
+                                {#each keyRows as row, index}
+                                    <div
+                                        class={`flex items-center justify-end pr-3 text-xs ${row.isBlack ? 'bg-muted/70 text-muted-foreground' : 'bg-background'} ${index === keyRows.length - 1 ? '' : 'border-b border-border/30'}`}
+                                        style={`height:${keyHeight}px;`}
+                                    >
+                                        {row.label}
+                                    </div>
+                                {/each}
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="relative flex-1 overflow-hidden bg-muted/20">
+                        <div class="relative h-full w-full overflow-auto" bind:this={gridScroller} onscroll={handleGridScroll}>
+                            <div class="sticky top-0 z-20 flex h-10 items-center border-b border-border/40 bg-background/95 px-4 text-xs font-medium text-muted-foreground backdrop-blur">
+                                <div class="relative h-full w-full" style={`min-width:${contentWidth}px;`}>
+                                    {#each beatMarkers as marker}
+                                        <div
+                                            class={`${marker.isBar ? 'font-semibold text-foreground' : 'text-muted-foreground'} absolute top-1/2 -translate-y-1/2`}
+                                            style={`left:${marker.left}px;`}
+                                        >
+                                            {#if marker.isBar}
+                                                Bar {Math.floor(marker.index / beatsPerBar) + 1}
+                                            {:else}
+                                                {marker.index + 1}
+                                            {/if}
+                                        </div>
+                                    {/each}
+                                </div>
+                            </div>
+                            <div
+                                class="relative"
+                                style={`width:${contentWidth}px; height:${gridHeight}px;`}
+                            >
+                                <TimelineGrid
+                                    gutterWidth={0}
+                                    class="z-10"
+                                    contentWidth={contentWidth}
+                                    scrollLeft={0}
+                                    barWidth={barWidth}
+                                    totalBars={totalBars}
+                                    beatsPerBar={beatsPerBar}
+                                    pxPerBeat={editorState.pxPerBeat}
+                                />
+
+                                {#each keyRows as row, index}
+                                    <div
+                                        class={`${row.isBlack ? 'bg-muted/60' : 'bg-background'} absolute left-0 right-0 ${index === keyRows.length - 1 ? '' : 'border-b border-border/30'}`}
+                                        style={`top:${index * keyHeight}px; height:${keyHeight}px;`}
+                                    ></div>
+                                {/each}
+
+                                {#each notesToRender as note}
+                                    <div
+                                        class="absolute z-30 rounded-sm bg-primary/80 shadow-sm"
+                                        style={`left:${note.left}px; top:${note.top}px; width:${note.width}px; height:${note.height}px;`}
+                                    ></div>
+                                {/each}
+                            </div>
+                        </div>
+                        <PlayheadCursor
+                            gutterWidth={0}
+                            class="z-40"
+                            scrollLeft={gridScrollLeft}
+                            pxPerTick={pxPerTick > 0 ? pxPerTick : 1}
+                            currentTick={cursorTick}
+                            tickOffset={sectionStartTick}
+                            visible={cursorVisible}
+                        />
+                    </div>
+                </div>
+            </div>
+        {/if}
+    </Sheet.Content>
+</Sheet.Root>
+
+<style>
+    .scrollbar-fade::-webkit-scrollbar {
+        width: 6px;
+    }
+
+    .scrollbar-fade::-webkit-scrollbar-track {
+        background: transparent;
+    }
+
+    .scrollbar-fade::-webkit-scrollbar-thumb {
+        background-color: rgba(148, 163, 184, 0.35);
+        border-radius: 9999px;
+    }
+
+    .scrollbar-fade {
+        scrollbar-width: thin;
+    }
+</style>

--- a/src/lib/components/editor/note-channel/note-piano-roll.svelte
+++ b/src/lib/components/editor/note-channel/note-piano-roll.svelte
@@ -190,6 +190,7 @@
                             totalBars={pianoRollState.totalBars}
                             beatsPerBar={pianoRollState.beatsPerBar}
                             pxPerBeat={editorState.pxPerBeat}
+                            startBar={pianoRollState.sectionStartBar}
                             showLabels
                         />
                     </RulerShell>
@@ -243,6 +244,7 @@
                                         totalBars={pianoRollState.totalBars}
                                         beatsPerBar={pianoRollState.beatsPerBar}
                                         pxPerBeat={editorState.pxPerBeat}
+                                        startBar={pianoRollState.sectionStartBar}
                                     />
 
                                     {#each pianoRollState.keyRows as row, index}

--- a/src/lib/components/editor/note-channel/note-section.svelte
+++ b/src/lib/components/editor/note-channel/note-section.svelte
@@ -163,6 +163,11 @@
             document.removeEventListener('noteended', handleNoteEnded as EventListener);
         };
     });
+
+    function handleOpenPianoRoll(event: MouseEvent) {
+        event.stopPropagation();
+        editorState.openPianoRoll(channelIndex, sectionIndex);
+    }
 </script>
 
 <!-- Simple visual block for a note section; color tokens are placeholders -->
@@ -174,6 +179,9 @@
     onpointermove={(ev) =>
         editorMouse.handleSectionPointerMove(channelIndex, sectionIndex, section, null, ev)}
     onpointerleave={() => editorMouse.handleSectionPointerLeave(channelIndex, sectionIndex)}
+    ondblclick={handleOpenPianoRoll}
+    role="button"
+    tabindex="0"
 >
     <!-- Header strip with section name -->
     <div class="w-full truncate bg-emerald-200/80 px-2 py-1 font-medium text-emerald-900">

--- a/src/lib/components/editor/note-channel/piano-roll-header.svelte
+++ b/src/lib/components/editor/note-channel/piano-roll-header.svelte
@@ -194,13 +194,12 @@
                         aria-label="Mute"
                         onclick={toggleMute}
                         class={cn(
-                            'h-8 w-8 p-0 text-xs font-bold',
                             isChannelMuted()
-                                ? 'bg-red-600 text-white hover:bg-red-600 dark:bg-red-600 dark:text-white hover:dark:bg-red-600'
+                                ? 'bg-red-600 text-white hover:bg-red-600/80 hover:text-white dark:hover:bg-red-600/80'
                                 : ''
                         )}
                     >
-                        M
+                        <span class="text-xs font-bold">M</span>
                     </Button>
                 {/snippet}
                 {@render tooltipped({
@@ -217,13 +216,12 @@
                         aria-label="Solo"
                         onclick={toggleSolo}
                         class={cn(
-                            'h-8 w-8 p-0 text-xs font-bold',
                             isAnyMuted && sectionData && !isChannelMuted()
-                                ? 'bg-yellow-600 text-white hover:bg-yellow-600 dark:bg-yellow-600 dark:text-white hover:dark:bg-yellow-600'
+                                ? 'bg-yellow-600 text-white hover:bg-yellow-600/80 hover:text-white dark:hover:bg-yellow-600/80'
                                 : ''
                         )}
                     >
-                        S
+                        <span class="text-xs font-bold">S</span>
                     </Button>
                 {/snippet}
                 {@render tooltipped({

--- a/src/lib/components/editor/note-channel/piano-roll-header.svelte
+++ b/src/lib/components/editor/note-channel/piano-roll-header.svelte
@@ -18,6 +18,8 @@
     import Play from '~icons/lucide/play';
     import Repeat from '~icons/lucide/repeat';
     import SkipBack from '~icons/lucide/skip-back';
+    import ZoomIn from '~icons/lucide/zoom-in';
+    import ZoomOut from '~icons/lucide/zoom-out';
 
     interface Props {
         sectionData: {
@@ -129,6 +131,28 @@
                 class="flex h-9 items-center rounded-md bg-background/20 px-3 font-mono text-sm tracking-widest tabular-nums shadow-xs select-none"
             >
                 {pianoRollState.positionBar}:{pianoRollState.positionBeat}:{pianoRollState.positionTickInBeat}
+            </div>
+
+            <div class="flex items-center gap-1 rounded-md bg-background/20 shadow-xs">
+                <Button
+                    variant="ghost"
+                    size="icon"
+                    onclick={() => editorState.zoomOut()}
+                    aria-label="Zoom out"
+                >
+                    <ZoomOut class="size-4" />
+                </Button>
+                <div class="min-w-14 text-center font-mono text-xs tabular-nums">
+                    {Math.round(editorState.pxPerBeat)} px/beat
+                </div>
+                <Button
+                    variant="ghost"
+                    size="icon"
+                    onclick={() => editorState.zoomIn()}
+                    aria-label="Zoom in"
+                >
+                    <ZoomIn class="size-4" />
+                </Button>
             </div>
         </div>
 

--- a/src/lib/components/editor/note-channel/piano-roll-header.svelte
+++ b/src/lib/components/editor/note-channel/piano-roll-header.svelte
@@ -40,6 +40,7 @@
 
     // Reactive state for solo/mute buttons
     const isChannelMuted = $derived(() => {
+        if (!sectionData) return false;
         const channel = player.song?.channels?.[sectionData.channelIndex];
         return channel?.kind === 'note' ? channel.isMuted : false;
     });
@@ -48,10 +49,12 @@
     );
 
     function toggleMute() {
+        if (!sectionData) return;
         player.setMute(sectionData.channelIndex);
     }
 
     function toggleSolo() {
+        if (!sectionData) return;
         player.setSolo(sectionData.channelIndex);
     }
 </script>
@@ -76,9 +79,13 @@
 {/snippet}
 
 <Sheet.Header class="border-b border-border/60 px-6 pt-6 pb-4">
-    <Sheet.Title class="text-lg font-semibold">{sectionData.section.name}</Sheet.Title>
+    <Sheet.Title class="text-lg font-semibold"
+        >{sectionData?.section?.name ?? 'Unknown Section'}</Sheet.Title
+    >
     <Sheet.Description class="text-sm text-muted-foreground">
-        {INSTRUMENT_NAMES[sectionData.channel.instrument]} • Channel {sectionData.channelIndex + 1} •
+        {sectionData ? INSTRUMENT_NAMES[sectionData.channel.instrument] : 'Unknown'} • Channel {sectionData
+            ? sectionData.channelIndex + 1
+            : '?'} •
         {sectionBeatLength} beats
     </Sheet.Description>
 </Sheet.Header>
@@ -178,6 +185,58 @@
         <div
             class="flex h-9 items-center gap-1.5 rounded-md bg-background/10 shadow-xs dark:bg-background/20"
         >
+            {#if sectionData}
+                {#snippet muteButton({ props }: { props: any })}
+                    <Button
+                        {...props}
+                        variant="ghost"
+                        size="icon"
+                        aria-label="Mute"
+                        onclick={toggleMute}
+                        class={cn(
+                            'h-8 w-8 p-0 text-xs font-bold',
+                            isChannelMuted()
+                                ? 'bg-red-600 text-white hover:bg-red-600 dark:bg-red-600 dark:text-white hover:dark:bg-red-600'
+                                : ''
+                        )}
+                    >
+                        M
+                    </Button>
+                {/snippet}
+                {@render tooltipped({
+                    label: isChannelMuted() ? 'Unmute' : 'Mute',
+                    children: muteButton,
+                    disableCloseOnTriggerClick: true
+                })}
+
+                {#snippet soloButton({ props }: { props: any })}
+                    <Button
+                        {...props}
+                        variant="ghost"
+                        size="icon"
+                        aria-label="Solo"
+                        onclick={toggleSolo}
+                        class={cn(
+                            'h-8 w-8 p-0 text-xs font-bold',
+                            isAnyMuted && sectionData && !isChannelMuted()
+                                ? 'bg-yellow-600 text-white hover:bg-yellow-600 dark:bg-yellow-600 dark:text-white hover:dark:bg-yellow-600'
+                                : ''
+                        )}
+                    >
+                        S
+                    </Button>
+                {/snippet}
+                {@render tooltipped({
+                    label: isAnyMuted && sectionData && !isChannelMuted() ? 'Unsolo' : 'Solo',
+                    children: soloButton,
+                    disableCloseOnTriggerClick: true
+                })}
+            {/if}
+        </div>
+
+        <div
+            class="flex h-9 items-center gap-1.5 rounded-md bg-background/10 shadow-xs dark:bg-background/20"
+        >
             {#snippet normalModeButton({ props }: { props: any })}
                 <Button
                     {...props}
@@ -237,56 +296,6 @@
                     ? 'Follow Playhead: On'
                     : 'Follow Playhead: Off',
                 children: autoScrollButton,
-                disableCloseOnTriggerClick: true
-            })}
-        </div>
-
-        <div
-            class="flex h-9 items-center gap-1.5 rounded-md bg-background/10 shadow-xs dark:bg-background/20"
-        >
-            {#snippet muteButton({ props }: { props: any })}
-                <Button
-                    {...props}
-                    variant="ghost"
-                    size="icon"
-                    aria-label="Mute"
-                    onclick={toggleMute}
-                    class={cn(
-                        'h-8 w-8 p-0 text-xs font-bold',
-                        isChannelMuted()
-                            ? 'bg-red-600 text-white hover:bg-red-600 dark:bg-red-600 dark:text-white hover:dark:bg-red-600'
-                            : ''
-                    )}
-                >
-                    M
-                </Button>
-            {/snippet}
-            {@render tooltipped({
-                label: isChannelMuted() ? 'Unmute' : 'Mute',
-                children: muteButton,
-                disableCloseOnTriggerClick: true
-            })}
-
-            {#snippet soloButton({ props }: { props: any })}
-                <Button
-                    {...props}
-                    variant="ghost"
-                    size="icon"
-                    aria-label="Solo"
-                    onclick={toggleSolo}
-                    class={cn(
-                        'h-8 w-8 p-0 text-xs font-bold',
-                        isAnyMuted && !isChannelMuted
-                            ? 'bg-yellow-600 text-white hover:bg-yellow-600 dark:bg-yellow-600 dark:text-white hover:dark:bg-yellow-600'
-                            : ''
-                    )}
-                >
-                    S
-                </Button>
-            {/snippet}
-            {@render tooltipped({
-                label: isAnyMuted && !isChannelMuted ? 'Unsolo' : 'Solo',
-                children: soloButton,
                 disableCloseOnTriggerClick: true
             })}
         </div>

--- a/src/lib/components/editor/note-channel/piano-roll-header.svelte
+++ b/src/lib/components/editor/note-channel/piano-roll-header.svelte
@@ -1,0 +1,201 @@
+<script lang="ts">
+    import Button from '$lib/components/ui/button/button.svelte';
+    import * as Sheet from '$lib/components/ui/sheet';
+    import {
+        TooltipContent,
+        TooltipProvider,
+        Tooltip as TooltipRoot,
+        TooltipTrigger
+    } from '$lib/components/ui/tooltip';
+    import { editorState, PointerMode } from '$lib/editor-state.svelte';
+    import { pianoRollState } from '$lib/piano-roll-state.svelte';
+    import { INSTRUMENT_NAMES, type Instrument } from '$lib/types';
+    import type { Snippet } from 'svelte';
+    import MousePointer from '~icons/lucide/mouse-pointer';
+    import MousePointerClick from '~icons/lucide/mouse-pointer-click';
+    import Pause from '~icons/lucide/pause';
+    import Pencil from '~icons/lucide/pencil';
+    import Play from '~icons/lucide/play';
+    import Repeat from '~icons/lucide/repeat';
+    import SkipBack from '~icons/lucide/skip-back';
+
+    interface Props {
+        sectionData: {
+            section: {
+                name: string;
+            };
+            channel: {
+                instrument: Instrument;
+            };
+            channelIndex: number;
+        };
+        sectionBeatLength: number;
+    }
+
+    let { sectionData, sectionBeatLength }: Props = $props();
+</script>
+
+{#snippet tooltipped({
+    label,
+    children,
+    disableCloseOnTriggerClick = false
+}: {
+    label: string;
+    children: Snippet<[{ props: any }]>;
+    disableCloseOnTriggerClick?: boolean;
+})}
+    <TooltipRoot {disableCloseOnTriggerClick}>
+        <TooltipTrigger>
+            {#snippet child({ props })}
+                {@render children?.({ props })}
+            {/snippet}
+        </TooltipTrigger>
+        <TooltipContent side="bottom">{label}</TooltipContent>
+    </TooltipRoot>
+{/snippet}
+
+<Sheet.Header class="border-b border-border/60 px-6 pt-6 pb-4">
+    <Sheet.Title class="text-lg font-semibold">{sectionData.section.name}</Sheet.Title>
+    <Sheet.Description class="text-sm text-muted-foreground">
+        {INSTRUMENT_NAMES[sectionData.channel.instrument]} • Channel {sectionData.channelIndex + 1} •
+        {sectionBeatLength} beats
+    </Sheet.Description>
+</Sheet.Header>
+
+<div
+    class="flex h-12 items-center gap-3 border-b border-border bg-secondary/80 px-4 text-secondary-foreground"
+>
+    <TooltipProvider>
+        <div class="flex flex-1 items-center gap-2">
+            <div
+                class="flex h-9 items-center gap-1.5 rounded-md bg-background/10 shadow-xs dark:bg-background/20"
+            >
+                {#snippet rewindButton({ props }: { props: any })}
+                    <Button
+                        {...props}
+                        variant="ghost"
+                        size="icon"
+                        aria-label="Rewind to start"
+                        onclick={pianoRollState.rewind}
+                    >
+                        <SkipBack class="size-5" />
+                    </Button>
+                {/snippet}
+                {@render tooltipped({
+                    label: 'Rewind to start',
+                    children: rewindButton
+                })}
+
+                {#snippet playPauseButton({ props }: { props: any })}
+                    <Button
+                        {...props}
+                        variant="ghost"
+                        size="icon"
+                        aria-label="Play/Pause"
+                        onclick={pianoRollState.togglePlay}
+                    >
+                        {#if pianoRollState.isPlaying}
+                            <Pause class="size-5" />
+                        {:else}
+                            <Play class="size-5" />
+                        {/if}
+                    </Button>
+                {/snippet}
+                {@render tooltipped({
+                    label: pianoRollState.isPlaying ? 'Pause' : 'Play',
+                    children: playPauseButton
+                })}
+
+                {#snippet loopButton({ props }: { props: any })}
+                    <Button
+                        {...props}
+                        variant="ghost"
+                        size="icon"
+                        aria-label="Loop"
+                        class={pianoRollState.loopModeButtonClass}
+                        onclick={pianoRollState.cycleLoop}
+                    >
+                        <Repeat class="size-5" />
+                    </Button>
+                {/snippet}
+                {@render tooltipped({
+                    label: pianoRollState.loopModeLabel,
+                    children: loopButton,
+                    disableCloseOnTriggerClick: true
+                })}
+            </div>
+
+            <div
+                class="flex h-9 items-center rounded-md bg-background/20 px-3 font-mono text-sm tracking-widest tabular-nums shadow-xs select-none"
+            >
+                {pianoRollState.positionBar}:{pianoRollState.positionBeat}:{pianoRollState.positionTickInBeat}
+            </div>
+        </div>
+
+        <div
+            class="flex h-9 items-center gap-1.5 rounded-md bg-background/10 shadow-xs dark:bg-background/20"
+        >
+            {#snippet normalModeButton({ props }: { props: any })}
+                <Button
+                    {...props}
+                    variant="ghost"
+                    size="icon"
+                    aria-label="Normal Mode"
+                    class={pianoRollState.pointerMode === PointerMode.Normal
+                        ? 'bg-indigo-600 text-white hover:bg-indigo-600/80 hover:text-white dark:hover:bg-indigo-600/80'
+                        : ''}
+                    onclick={() => pianoRollState.setPointerMode(PointerMode.Normal)}
+                >
+                    <MousePointer class="size-5" />
+                </Button>
+            {/snippet}
+            {@render tooltipped({
+                label: 'Normal Mode',
+                children: normalModeButton,
+                disableCloseOnTriggerClick: true
+            })}
+
+            {#snippet penModeButton({ props }: { props: any })}
+                <Button
+                    {...props}
+                    variant="ghost"
+                    size="icon"
+                    aria-label="Pen Mode"
+                    class={pianoRollState.pointerMode === 'pen'
+                        ? 'bg-indigo-600 text-white hover:bg-indigo-600/80 hover:text-white dark:hover:bg-indigo-600/80'
+                        : ''}
+                    onclick={() => pianoRollState.setPointerMode('pen')}
+                >
+                    <Pencil class="size-5" />
+                </Button>
+            {/snippet}
+            {@render tooltipped({
+                label: 'Pen Mode',
+                children: penModeButton,
+                disableCloseOnTriggerClick: true
+            })}
+
+            {#snippet autoScrollButton({ props }: { props: any })}
+                <Button
+                    {...props}
+                    variant="ghost"
+                    size="icon"
+                    aria-label="Follow Playhead"
+                    onclick={() => editorState.setAutoScrollEnabled(!editorState.autoScrollEnabled)}
+                    class={editorState.autoScrollEnabled
+                        ? 'bg-primary text-primary-foreground hover:bg-primary/90 hover:text-primary-foreground dark:hover:bg-primary/90'
+                        : ''}
+                >
+                    <MousePointerClick class="size-5" />
+                </Button>
+            {/snippet}
+            {@render tooltipped({
+                label: editorState.autoScrollEnabled
+                    ? 'Follow Playhead: On'
+                    : 'Follow Playhead: Off',
+                children: autoScrollButton,
+                disableCloseOnTriggerClick: true
+            })}
+        </div>
+    </TooltipProvider>
+</div>

--- a/src/lib/components/editor/note-channel/piano-roll-mouse-window-events.svelte
+++ b/src/lib/components/editor/note-channel/piano-roll-mouse-window-events.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+    import { pianoRollMouse } from '$lib/piano-roll-mouse.svelte';
+</script>
+
+<svelte:window
+    onpointermove={pianoRollMouse.handleWindowPointerMove}
+    onpointerup={pianoRollMouse.handleWindowPointerUp}
+    onpointercancel={pianoRollMouse.handleWindowPointerCancel}
+    onkeydown={pianoRollMouse.handleWindowKeyDown}
+/>

--- a/src/lib/components/editor/playhead-cursor.svelte
+++ b/src/lib/components/editor/playhead-cursor.svelte
@@ -3,18 +3,36 @@
     import { player } from '$lib/playback.svelte';
 
     interface Props {
-        gutterWidth?: number; // px to offset from the left (to skip gutters)
+        gutterWidth?: number;
         class?: string;
+        scrollLeft?: number;
+        pxPerTick?: number;
+        currentTick?: number;
+        tickOffset?: number;
+        visible?: boolean;
     }
 
-    let { gutterWidth = 0, class: className = '' }: Props = $props();
+    let {
+        gutterWidth = 0,
+        class: className = '',
+        scrollLeft: scrollLeftProp,
+        pxPerTick: pxPerTickProp,
+        currentTick: currentTickProp,
+        tickOffset: tickOffsetProp = 0,
+        visible: visibleProp
+    }: Props = $props();
 
-    // Compute position in viewport space: contentX - scrollLeft
-    const pxPerTick = $derived(
+    const defaultPxPerTick = $derived(
         editorState.ticksPerBeat > 0 ? editorState.pxPerBeat / editorState.ticksPerBeat : 0
     );
-    const contentX = $derived(player.currentTick * pxPerTick);
-    const viewportX = $derived(contentX - editorState.scrollLeft);
+    const pxPerTick = $derived(Math.max(0, pxPerTickProp ?? defaultPxPerTick));
+    const scrollLeft = $derived(scrollLeftProp ?? editorState.scrollLeft);
+    const currentTick = $derived(currentTickProp ?? player.currentTick);
+    const tickOffset = $derived(tickOffsetProp ?? 0);
+    const visible = $derived(visibleProp ?? true);
+
+    const contentX = $derived(Math.max(0, (currentTick - tickOffset) * pxPerTick));
+    const viewportX = $derived(contentX - scrollLeft);
     const cursorTransitionMs = $derived(Math.max(0, Math.round(1000 / player.tempo)));
 </script>
 
@@ -23,11 +41,12 @@
     class={`pointer-events-none absolute inset-y-0 right-0 z-30 ${className}`}
     style={`left:${gutterWidth}px`}
 >
-    <div
-        class="absolute top-0 bottom-0"
-        style={`transform:translateX(${viewportX}px); transition: transform ${cursorTransitionMs}ms linear;`}
-    >
-        <div class="h-full w-[2px] bg-primary shadow-[0_0_0_1px_hsl(var(--background))]"></div>
-    </div>
-    <!-- Optional: add a slight glow to improve contrast on busy grids -->
+    {#if visible}
+        <div
+            class="absolute top-0 bottom-0"
+            style={`transform:translateX(${viewportX}px); transition: transform ${cursorTransitionMs}ms linear;`}
+        >
+            <div class="h-full w-[2px] bg-primary shadow-[0_0_0_1px_hsl(var(--background))]"></div>
+        </div>
+    {/if}
 </div>

--- a/src/lib/components/editor/ruler-shell.svelte
+++ b/src/lib/components/editor/ruler-shell.svelte
@@ -1,0 +1,86 @@
+<script lang="ts">
+    import { createEventDispatcher, type Snippet } from 'svelte';
+    import { cn } from '$lib/utils';
+
+    interface Props {
+        class?: string;
+        gutterWidth?: number;
+        gutterClass?: string;
+        timelineClass?: string;
+        contentClass?: string;
+        contentWidth?: number;
+        scrollLeft?: number;
+        pointerDownHandler?: (container: HTMLElement, event: PointerEvent) => void;
+    }
+
+    const dispatch = createEventDispatcher<{ scrollLeftChange: number }>();
+
+    let {
+        class: className,
+        gutterWidth = 240,
+        gutterClass = 'flex items-center gap-2 border-r border-border px-3 py-2',
+        timelineClass = 'scrollbar-thin relative h-full flex-1 overflow-x-auto overflow-y-hidden bg-background',
+        contentClass = 'relative h-full cursor-crosshair',
+        contentWidth,
+        scrollLeft = 0,
+        pointerDownHandler,
+        gutter,
+        children
+    }: Props & {
+        gutter?: Snippet;
+        children?: Snippet;
+    } = $props();
+
+    let scroller: HTMLDivElement | null = null;
+    let contentEl: HTMLDivElement | null = null;
+
+    // Keep the internal scroller aligned with the provided scrollLeft prop
+    $effect(() => {
+        const el = scroller;
+        if (!el) return;
+        if (Math.abs(el.scrollLeft - scrollLeft) > 1) {
+            el.scrollLeft = scrollLeft;
+        }
+    });
+
+    function handleScroll() {
+        const el = scroller;
+        if (!el) return;
+        const left = el.scrollLeft;
+        dispatch('scrollLeftChange', left);
+    }
+
+    function handlePointerDown(event: PointerEvent) {
+        if (!pointerDownHandler) return;
+        pointerDownHandler(contentEl ?? (event.currentTarget as HTMLElement), event);
+    }
+</script>
+
+<div class={cn('flex w-full select-none', className)}>
+    <div class={cn('flex-shrink-0', gutterClass)} style={`width:${gutterWidth}px`}>
+        {@render gutter?.()}
+    </div>
+    <div bind:this={scroller} class={cn(timelineClass)} onscroll={handleScroll}>
+        <div
+            bind:this={contentEl}
+            class={cn(contentClass)}
+            style={contentWidth != null ? `width:${contentWidth}px` : undefined}
+            onpointerdown={handlePointerDown}
+        >
+            {@render children?.()}
+        </div>
+    </div>
+</div>
+
+<style>
+    .scrollbar-thin::-webkit-scrollbar {
+        height: 0px;
+    }
+    .scrollbar-thin::-webkit-scrollbar-thumb {
+        background-color: hsl(var(--muted-foreground) / 0.25);
+        border-radius: 8px;
+    }
+    .scrollbar-thin::-webkit-scrollbar-track {
+        background: transparent;
+    }
+</style>

--- a/src/lib/components/editor/selection-overlay.svelte
+++ b/src/lib/components/editor/selection-overlay.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import { editorState } from '$lib/editor-state.svelte';
     import { player } from '$lib/playback.svelte';
+    import SelectionRectangleOverlay from './selection-rectangle-overlay.svelte';
 
     interface Props {
         class?: string;
@@ -28,17 +29,23 @@
               )
             : 0
     );
-    const innerLeft = $derived(contentLeft - editorState.scrollLeft);
+    const rect = $derived(
+        hasSelection
+            ? {
+                  left: contentLeft,
+                  top: 0,
+                  width,
+                  height: 1
+              }
+            : null
+    );
 </script>
 
-{#if hasSelection}
-    <div
-        class={`pointer-events-none absolute z-20 ${className}`}
-        style={`top:0; bottom:0; left:${gutterWidth}px; right:0;`}
-    >
-        <div
-            class="absolute inset-y-0 rounded-sm bg-primary/20 outline-1 outline-primary/50"
-            style={`left:${innerLeft}px; width:${width}px;`}
-        ></div>
-    </div>
-{/if}
+<SelectionRectangleOverlay
+    {rect}
+    {gutterWidth}
+    scrollLeft={editorState.scrollLeft}
+    class={className}
+    stretchY
+    overlayClass="rounded-sm bg-primary/20 outline outline-1 outline-primary/50"
+/>

--- a/src/lib/components/editor/selection-rectangle-overlay.svelte
+++ b/src/lib/components/editor/selection-rectangle-overlay.svelte
@@ -1,0 +1,46 @@
+<script lang="ts">
+    export interface OverlayRect {
+        left: number;
+        top: number;
+        width: number;
+        height: number;
+    }
+
+    interface Props {
+        rect: OverlayRect | null;
+        gutterWidth?: number;
+        scrollLeft?: number;
+        scrollTop?: number;
+        class?: string;
+        stretchY?: boolean;
+        overlayClass?: string;
+    }
+
+    let {
+        rect,
+        gutterWidth = 0,
+        scrollLeft = 0,
+        scrollTop = 0,
+        class: className = '',
+        stretchY = false,
+        overlayClass = 'rounded-sm border-2 border-indigo-400/70 bg-indigo-500/10'
+    }: Props = $props();
+
+    const visible = $derived(Boolean(rect));
+    const viewportLeft = $derived(visible && rect ? Math.round(rect.left - scrollLeft) : 0);
+    const viewportTop = $derived(visible && rect ? Math.round(rect.top - scrollTop) : 0);
+    const width = $derived(visible && rect ? Math.max(1, Math.round(rect.width)) : 0);
+    const height = $derived(visible && rect ? Math.max(1, Math.round(rect.height)) : 0);
+</script>
+
+{#if visible && rect}
+    <div
+        class={`pointer-events-none absolute inset-y-0 right-0 z-20 ${className}`}
+        style={`left:${gutterWidth}px;`}
+    >
+        <div
+            class={`absolute ${overlayClass}`}
+            style={`left:${viewportLeft}px; ${stretchY ? 'top:0; bottom:0;' : `top:${viewportTop}px; height:${height}px;`} width:${width}px;`}
+        ></div>
+    </div>
+{/if}

--- a/src/lib/components/editor/timeline-grid.svelte
+++ b/src/lib/components/editor/timeline-grid.svelte
@@ -5,9 +5,32 @@
         showLabels?: boolean;
         class?: string;
         gutterWidth?: number;
+        contentWidth?: number;
+        scrollLeft?: number;
+        barWidth?: number;
+        totalBars?: number;
+        beatsPerBar?: number;
+        pxPerBeat?: number;
     }
 
-    let { showLabels = false, class: className = '', gutterWidth = 0 }: Props = $props();
+    let {
+        showLabels = false,
+        class: className = '',
+        gutterWidth = 0,
+        contentWidth: contentWidthProp,
+        scrollLeft: scrollLeftProp,
+        barWidth: barWidthProp,
+        totalBars: totalBarsProp,
+        beatsPerBar: beatsPerBarProp,
+        pxPerBeat: pxPerBeatProp
+    }: Props = $props();
+
+    const contentWidth = $derived(contentWidthProp ?? editorState.contentWidth);
+    const scrollLeft = $derived(scrollLeftProp ?? editorState.scrollLeft);
+    const barWidth = $derived(Math.max(1, barWidthProp ?? editorState.barWidth));
+    const totalBars = $derived(Math.max(1, Math.round(totalBarsProp ?? editorState.totalBars)));
+    const beatsPerBar = $derived(Math.max(1, beatsPerBarProp ?? editorState.beatsPerBar));
+    const pxPerBeat = $derived(Math.max(1, pxPerBeatProp ?? editorState.pxPerBeat));
 
     const range = (n: number) => Array.from({ length: n }, (_, i) => i);
 </script>
@@ -19,12 +42,12 @@
 >
     <div
         class="relative h-full"
-        style={`width:${editorState.contentWidth}px; transform:translateX(${-editorState.scrollLeft}px);`}
+        style={`width:${contentWidth}px; transform:translateX(${-scrollLeft}px);`}
     >
-        {#each range(editorState.totalBars) as barIdx}
+        {#each range(totalBars) as barIdx}
             <div
                 class="absolute inset-y-0 border-r border-border"
-                style={`left:${barIdx * editorState.barWidth}px; width:${editorState.barWidth}px; ${barIdx % 2 === 1 ? 'background-color:hsl(var(--secondary)/0.25)' : ''}`}
+                style={`left:${barIdx * barWidth}px; width:${barWidth}px; ${barIdx % 2 === 1 ? 'background-color:hsl(var(--secondary)/0.25)' : ''}`}
             >
                 {#if showLabels}
                     <div
@@ -33,11 +56,11 @@
                         {barIdx + 1}
                     </div>
                 {/if}
-                {#each range(editorState.beatsPerBar) as beatIdx}
+                {#each range(beatsPerBar) as beatIdx}
                     {#if beatIdx > 0}
                         <div
                             class="absolute inset-y-0 border-l border-border/80"
-                            style={`left:${beatIdx * editorState.pxPerBeat}px`}
+                            style={`left:${beatIdx * pxPerBeat}px`}
                         ></div>
                     {/if}
                 {/each}

--- a/src/lib/components/editor/timeline-grid.svelte
+++ b/src/lib/components/editor/timeline-grid.svelte
@@ -11,6 +11,7 @@
         totalBars?: number;
         beatsPerBar?: number;
         pxPerBeat?: number;
+        startBar?: number;
     }
 
     let {
@@ -22,7 +23,8 @@
         barWidth: barWidthProp,
         totalBars: totalBarsProp,
         beatsPerBar: beatsPerBarProp,
-        pxPerBeat: pxPerBeatProp
+        pxPerBeat: pxPerBeatProp,
+        startBar = 0
     }: Props = $props();
 
     const contentWidth = $derived(contentWidthProp ?? editorState.contentWidth);
@@ -53,7 +55,7 @@
                     <div
                         class="absolute top-1 left-1 rounded bg-secondary px-1.5 py-0.5 text-[11px] leading-none text-secondary-foreground"
                     >
-                        {barIdx + 1}
+                        {barIdx + startBar + 1}
                     </div>
                 {/if}
                 {#each range(beatsPerBar) as beatIdx}

--- a/src/lib/components/ui/sheet/index.ts
+++ b/src/lib/components/ui/sheet/index.ts
@@ -1,0 +1,36 @@
+import { Dialog as SheetPrimitive } from "bits-ui";
+import Trigger from "./sheet-trigger.svelte";
+import Close from "./sheet-close.svelte";
+import Overlay from "./sheet-overlay.svelte";
+import Content from "./sheet-content.svelte";
+import Header from "./sheet-header.svelte";
+import Footer from "./sheet-footer.svelte";
+import Title from "./sheet-title.svelte";
+import Description from "./sheet-description.svelte";
+
+const Root = SheetPrimitive.Root;
+const Portal = SheetPrimitive.Portal;
+
+export {
+	Root,
+	Close,
+	Trigger,
+	Portal,
+	Overlay,
+	Content,
+	Header,
+	Footer,
+	Title,
+	Description,
+	//
+	Root as Sheet,
+	Close as SheetClose,
+	Trigger as SheetTrigger,
+	Portal as SheetPortal,
+	Overlay as SheetOverlay,
+	Content as SheetContent,
+	Header as SheetHeader,
+	Footer as SheetFooter,
+	Title as SheetTitle,
+	Description as SheetDescription,
+};

--- a/src/lib/components/ui/sheet/sheet-close.svelte
+++ b/src/lib/components/ui/sheet/sheet-close.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import { Dialog as SheetPrimitive } from "bits-ui";
+
+	let { ref = $bindable(null), ...restProps }: SheetPrimitive.CloseProps = $props();
+</script>
+
+<SheetPrimitive.Close bind:ref data-slot="sheet-close" {...restProps} />

--- a/src/lib/components/ui/sheet/sheet-content.svelte
+++ b/src/lib/components/ui/sheet/sheet-content.svelte
@@ -1,0 +1,58 @@
+<script lang="ts" module>
+	import { tv, type VariantProps } from "tailwind-variants";
+	export const sheetVariants = tv({
+		base: "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-50 flex flex-col gap-4 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
+		variants: {
+			side: {
+				top: "data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top inset-x-0 top-0 h-auto border-b",
+				bottom: "data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom inset-x-0 bottom-0 h-auto border-t",
+				left: "data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left inset-y-0 left-0 h-full w-3/4 border-r sm:max-w-sm",
+				right: "data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right inset-y-0 right-0 h-full w-3/4 border-l sm:max-w-sm",
+			},
+		},
+		defaultVariants: {
+			side: "right",
+		},
+	});
+
+	export type Side = VariantProps<typeof sheetVariants>["side"];
+</script>
+
+<script lang="ts">
+	import { Dialog as SheetPrimitive } from "bits-ui";
+	import XIcon from "@lucide/svelte/icons/x";
+	import type { Snippet } from "svelte";
+	import SheetOverlay from "./sheet-overlay.svelte";
+	import { cn, type WithoutChildrenOrChild } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		side = "right",
+		portalProps,
+		children,
+		...restProps
+	}: WithoutChildrenOrChild<SheetPrimitive.ContentProps> & {
+		portalProps?: SheetPrimitive.PortalProps;
+		side?: Side;
+		children: Snippet;
+	} = $props();
+</script>
+
+<SheetPrimitive.Portal {...portalProps}>
+	<SheetOverlay />
+	<SheetPrimitive.Content
+		bind:ref
+		data-slot="sheet-content"
+		class={cn(sheetVariants({ side }), className)}
+		{...restProps}
+	>
+		{@render children?.()}
+		<SheetPrimitive.Close
+			class="ring-offset-background focus-visible:ring-ring rounded-xs focus-visible:outline-hidden absolute right-4 top-4 opacity-70 transition-opacity hover:opacity-100 focus-visible:ring-2 focus-visible:ring-offset-2 disabled:pointer-events-none"
+		>
+			<XIcon class="size-4" />
+			<span class="sr-only">Close</span>
+		</SheetPrimitive.Close>
+	</SheetPrimitive.Content>
+</SheetPrimitive.Portal>

--- a/src/lib/components/ui/sheet/sheet-description.svelte
+++ b/src/lib/components/ui/sheet/sheet-description.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	import { Dialog as SheetPrimitive } from "bits-ui";
+	import { cn } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		...restProps
+	}: SheetPrimitive.DescriptionProps = $props();
+</script>
+
+<SheetPrimitive.Description
+	bind:ref
+	data-slot="sheet-description"
+	class={cn("text-muted-foreground text-sm", className)}
+	{...restProps}
+/>

--- a/src/lib/components/ui/sheet/sheet-footer.svelte
+++ b/src/lib/components/ui/sheet/sheet-footer.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import { cn, type WithElementRef } from "$lib/utils.js";
+	import type { HTMLAttributes } from "svelte/elements";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="sheet-footer"
+	class={cn("mt-auto flex flex-col gap-2 p-4", className)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/src/lib/components/ui/sheet/sheet-header.svelte
+++ b/src/lib/components/ui/sheet/sheet-header.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import type { HTMLAttributes } from "svelte/elements";
+	import { cn, type WithElementRef } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="sheet-header"
+	class={cn("flex flex-col gap-1.5 p-4", className)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/src/lib/components/ui/sheet/sheet-overlay.svelte
+++ b/src/lib/components/ui/sheet/sheet-overlay.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import { Dialog as SheetPrimitive } from "bits-ui";
+	import { cn } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		...restProps
+	}: SheetPrimitive.OverlayProps = $props();
+</script>
+
+<SheetPrimitive.Overlay
+	bind:ref
+	data-slot="sheet-overlay"
+	class={cn(
+		"data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+		className
+	)}
+	{...restProps}
+/>

--- a/src/lib/components/ui/sheet/sheet-title.svelte
+++ b/src/lib/components/ui/sheet/sheet-title.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	import { Dialog as SheetPrimitive } from "bits-ui";
+	import { cn } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		...restProps
+	}: SheetPrimitive.TitleProps = $props();
+</script>
+
+<SheetPrimitive.Title
+	bind:ref
+	data-slot="sheet-title"
+	class={cn("text-foreground font-semibold", className)}
+	{...restProps}
+/>

--- a/src/lib/components/ui/sheet/sheet-trigger.svelte
+++ b/src/lib/components/ui/sheet/sheet-trigger.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import { Dialog as SheetPrimitive } from "bits-ui";
+
+	let { ref = $bindable(null), ...restProps }: SheetPrimitive.TriggerProps = $props();
+</script>
+
+<SheetPrimitive.Trigger bind:ref data-slot="sheet-trigger" {...restProps} />

--- a/src/lib/editor-state.svelte.ts
+++ b/src/lib/editor-state.svelte.ts
@@ -27,6 +27,12 @@ export class EditorState {
     // Stored as an array of { channelIndex, sectionIndex } for simplicity.
     selectedSections = $state<Array<{ channelIndex: number; sectionIndex: number }>>([]);
 
+    // Current section opened in the piano roll editor (null when closed)
+    pianoRollTarget = $state<{
+        channelIndex: number;
+        sectionIndex: number;
+    } | null>(null);
+
     // Select a set of sections (overwrites current)
     setSelectedSections(selections: Array<{ channelIndex: number; sectionIndex: number }>) {
         this.selectedSections = selections;
@@ -114,6 +120,14 @@ export class EditorState {
 
     setPointerMode(mode: PointerMode) {
         this.pointerMode = mode;
+    }
+
+    openPianoRoll(channelIndex: number, sectionIndex: number) {
+        this.pianoRollTarget = { channelIndex, sectionIndex };
+    }
+
+    closePianoRoll() {
+        this.pianoRollTarget = null;
     }
 }
 

--- a/src/lib/piano-roll-mouse.svelte.ts
+++ b/src/lib/piano-roll-mouse.svelte.ts
@@ -3,14 +3,24 @@ import { player } from '$lib/playback.svelte';
 import type { Note, NoteSection } from '$lib/types';
 
 export type PianoRollPointerMode = PointerMode.Normal | 'pen';
+
+// Forward declaration to avoid circular import
+interface PianoRollState {
+    pointerMode: PianoRollPointerMode;
+    selectedNotes: Note[];
+    selectionBox: { startTick: number; startKey: number; currentTick: number; currentKey: number } | null;
+    selectionOverlayRect: { left: number; top: number; width: number; height: number } | null;
+    gridContent: HTMLDivElement | null;
+    keyRange: { min: number; max: number };
+    keyHeight: number;
+    pxPerTick: number;
+    sectionData: { section: NoteSection } | null;
+    isMouseActive: boolean;
+    selectNotes: (notes: Note[]) => void;
+    clearSelection: () => void;
+}
 export type KeyRange = { min: number; max: number };
 
-type SelectionBox = {
-    startTick: number;
-    startKey: number;
-    currentTick: number;
-    currentKey: number;
-};
 
 type DragContext = {
     notes: Note[];
@@ -30,12 +40,6 @@ type SelectionContext = { pointerId: number; startTick: number; startKey: number
 const POINTER_MOVE_HANDLED = Symbol('pianoRollPointerMoveHandled');
 const POINTER_UP_HANDLED = Symbol('pianoRollPointerUpHandled');
 
-type OverlayRect = {
-    left: number;
-    top: number;
-    width: number;
-    height: number;
-};
 
 const NOTE_SPAN = 1;
 const DEFAULT_NOTE_VELOCITY = 100;
@@ -48,125 +52,48 @@ function isEditableTarget(target: EventTarget | null): boolean {
 }
 
 export class PianoRollMouseController {
-    // Public reactive state
-    selectedNotes = $state<Note[]>([]);
-    selectionBox = $state<SelectionBox | null>(null);
-    selectionOverlayRect = $state<OverlayRect | null>(null);
-    isActive = $state(false);
-
-    gridContent = $state<HTMLDivElement | null>(null);
-
-    private _pxPerTick = 1;
-    private _keyRange: KeyRange = { min: 0, max: 87 };
-    private _keyHeight = 20;
-
-    private _section: NoteSection | null = null;
-    private _pointerMode: PianoRollPointerMode = PointerMode.Normal;
+    private pianoRollState: PianoRollState | null = null;
 
     private dragContext: DragContext | null = null;
     private selectionContext: SelectionContext = null;
-    private overlayPendingRect: OverlayRect | null = null;
-    private overlayFrameId: number | null = null;
 
-    setPointerMode = (mode: PianoRollPointerMode) => {
-        // Early exit if mode hasn't changed to prevent unnecessary updates
-        if (this._pointerMode === mode) return;
+    setPianoRollState(state: PianoRollState) {
+        this.pianoRollState = state;
+    }
 
-        this._pointerMode = mode;
-
-        // Always clear selection state when changing modes to ensure clean state
-        this.selectionBox = null;
-        this.selectionOverlayRect = null;
-        this.selectionContext = null;
-        this.dragContext = null;
-        this.overlayPendingRect = null;
-        this.cancelOverlayFrame();
-
-        // In pen mode, also clear any selected notes to start fresh
-        if (mode === 'pen') {
-            this.clearSelection();
-        }
-    };
-
-    setActive = (active: boolean) => {
-        this.isActive = active;
-        if (!active) {
-            this.clearSelection();
-            this.selectionBox = null;
-            this.selectionOverlayRect = null;
-            this.dragContext = null;
-            this.selectionContext = null;
-            this.overlayPendingRect = null;
-            this.cancelOverlayFrame();
-        }
-    };
-
-    setGridContent = (element: HTMLDivElement | null) => {
-        this.gridContent = element;
-    };
-
-    setSection = (section: NoteSection | null) => {
-        this._section = section;
-        this.syncSelectedNotes();
-    };
-
-    updateGeometry = ({
-        pxPerTick,
-        keyRange,
-        keyHeight
-    }: {
-        pxPerTick: number;
-        keyRange: KeyRange;
-        keyHeight: number;
-    }) => {
-        const newPxPerTick = pxPerTick > 0 ? pxPerTick : 1;
-        const hasChanged =
-            this._pxPerTick !== newPxPerTick ||
-            this._keyRange.min !== keyRange.min ||
-            this._keyRange.max !== keyRange.max ||
-            this._keyHeight !== keyHeight;
-
-        if (!hasChanged) return;
-
-        this._pxPerTick = newPxPerTick;
-        this._keyRange = keyRange;
-        this._keyHeight = keyHeight;
-        this.updateSelectionOverlayRect();
-    };
+    // Mouse controllers should be stateless - all state managed by pianoRollState
 
     handleBackgroundPointerDown = (event: PointerEvent) => {
         if (event.button !== 0) return;
+        if (!this.pianoRollState) return;
         event.preventDefault();
-
-        const section = this._section;
-        const grid = this.gridContent;
-        const pointerMode = this._pointerMode;
 
         const tick = this.clampTickToSection(this.tickFromPointer(event));
         const key = this.keyFromPointer(event);
 
-        if (pointerMode === PointerMode.Normal) {
+        if (this.pianoRollState.pointerMode === PointerMode.Normal) {
             this.selectionContext = { pointerId: event.pointerId, startTick: tick, startKey: key };
-            this.selectionBox = {
+            this.pianoRollState.selectionBox = {
                 startTick: tick,
                 startKey: key,
                 currentTick: tick,
                 currentKey: key
             };
             this.updateSelectionOverlayRect();
-            this.clearSelection();
-            grid?.setPointerCapture(event.pointerId);
-        } else if (pointerMode === 'pen') {
+            this.pianoRollState.clearSelection();
+            this.pianoRollState.gridContent?.setPointerCapture(event.pointerId);
+        } else if (this.pianoRollState.pointerMode === 'pen') {
             // Clear any existing selection state when in pen mode
             this.selectionContext = null;
-            this.selectionBox = null;
-            this.selectionOverlayRect = null;
+            this.pianoRollState.selectionBox = null;
+            this.pianoRollState.selectionOverlayRect = null;
             this.dragContext = null;
 
+            const section = this.pianoRollState.sectionData?.section;
             if (!section) return;
             const existing = this.findNoteAt(tick, key);
             if (existing) {
-                this.selectNotes([existing]);
+                this.pianoRollState.selectNotes([existing]);
             } else {
                 const newNote: Note = {
                     tick,
@@ -176,7 +103,7 @@ export class PianoRollMouseController {
                 };
                 section.notes.push(newNote);
                 this.sortSectionNotes(section);
-                this.selectNotes([newNote]);
+                this.pianoRollState.selectNotes([newNote]);
                 this.refreshPlayer();
             }
             // Don't capture pointer in pen mode to avoid interfering with note creation
@@ -185,18 +112,19 @@ export class PianoRollMouseController {
 
     handleNotePointerDown = (note: Note, event: PointerEvent) => {
         if (event.button !== 0) return;
+        if (!this.pianoRollState) return;
         event.preventDefault();
         event.stopPropagation();
 
-        const section = this._section;
+        const section = this.pianoRollState.sectionData?.section;
         if (!section) return;
 
-        if (this._pointerMode === PointerMode.Normal) {
-            if (!this.selectedNotes.includes(note)) {
-                this.selectNotes([note]);
+        if (this.pianoRollState.pointerMode === PointerMode.Normal) {
+            if (!this.pianoRollState.selectedNotes.includes(note)) {
+                this.pianoRollState.selectNotes([note]);
             }
 
-            const notes = [...this.selectedNotes];
+            const notes = [...this.pianoRollState.selectedNotes];
             const original = new Map<Note, { tick: number; key: number }>();
             let minTick = Number.POSITIVE_INFINITY;
             let maxTick = Number.NEGATIVE_INFINITY;
@@ -228,14 +156,14 @@ export class PianoRollMouseController {
                 moved: false
             };
 
-            this.gridContent?.setPointerCapture(event.pointerId);
-        } else if (this._pointerMode === 'pen') {
+            this.pianoRollState.gridContent?.setPointerCapture(event.pointerId);
+        } else if (this.pianoRollState.pointerMode === 'pen') {
             // In pen mode, just select the note and clear any selection state
             this.selectionContext = null;
-            this.selectionBox = null;
-            this.selectionOverlayRect = null;
+            this.pianoRollState.selectionBox = null;
+            this.pianoRollState.selectionOverlayRect = null;
             this.dragContext = null;
-            this.selectNotes([note]);
+            this.pianoRollState.selectNotes([note]);
         }
     };
 
@@ -273,16 +201,17 @@ export class PianoRollMouseController {
     };
 
     private processPointerMove(event: PointerEvent) {
-        const section = this._section;
+        if (!this.pianoRollState) return;
+        const section = this.pianoRollState.sectionData?.section;
         if (!section) return;
 
         // Early exit if in pen mode - no selection or drag behavior
-        if (this._pointerMode === 'pen') {
+        if (this.pianoRollState.pointerMode === 'pen') {
             return;
         }
 
         // Only process drag and selection in Normal mode
-        if (this._pointerMode !== PointerMode.Normal) {
+        if (this.pianoRollState.pointerMode !== PointerMode.Normal) {
             return;
         }
 
@@ -315,7 +244,7 @@ export class PianoRollMouseController {
         if (this.selectionContext && this.selectionContext.pointerId === event.pointerId) {
             const tick = this.tickFromPointer(event);
             const key = this.keyFromPointer(event);
-            this.selectionBox = {
+            this.pianoRollState.selectionBox = {
                 startTick: this.selectionContext.startTick,
                 startKey: this.selectionContext.startKey,
                 currentTick: tick,
@@ -336,18 +265,19 @@ export class PianoRollMouseController {
                 const withinKey = n.key >= minKey && n.key <= maxKey;
                 if (overlapsTick && withinKey) notes.push(n);
             }
-            this.selectNotes(notes);
+            this.pianoRollState.selectNotes(notes);
         }
     }
 
     private finishPointerInteraction(event: PointerEvent) {
-        const section = this._section;
+        if (!this.pianoRollState) return;
+        const section = this.pianoRollState.sectionData?.section;
 
         // In pen mode, just clean up any stale state and exit early
-        if (this._pointerMode === 'pen') {
+        if (this.pianoRollState.pointerMode === 'pen') {
             this.selectionContext = null;
-            this.selectionBox = null;
-            this.selectionOverlayRect = null;
+            this.pianoRollState.selectionBox = null;
+            this.pianoRollState.selectionOverlayRect = null;
             this.dragContext = null;
             return;
         }
@@ -361,25 +291,24 @@ export class PianoRollMouseController {
         }
 
         if (this.selectionContext && this.selectionContext.pointerId === event.pointerId) {
-            const box = this.selectionBox;
+            const box = this.pianoRollState.selectionBox;
             if (
                 box &&
                 box.startTick === box.currentTick &&
                 box.startKey === box.currentKey &&
-                this._pointerMode === PointerMode.Normal
+                this.pianoRollState.pointerMode === PointerMode.Normal
             ) {
-                this.clearSelection();
+                this.pianoRollState.clearSelection();
             }
             this.selectionContext = null;
-            this.selectionBox = null;
+            this.pianoRollState.selectionBox = null;
             this.updateSelectionOverlayRect();
         }
 
-        const grid = this.gridContent;
-        if (grid) {
+        if (this.pianoRollState.gridContent) {
             try {
-                if (grid.hasPointerCapture(event.pointerId)) {
-                    grid.releasePointerCapture(event.pointerId);
+                if (this.pianoRollState.gridContent.hasPointerCapture(event.pointerId)) {
+                    this.pianoRollState.gridContent.releasePointerCapture(event.pointerId);
                 }
             } catch {
                 // ignore
@@ -388,16 +317,17 @@ export class PianoRollMouseController {
     }
 
     handleWindowKeyDown = (event: KeyboardEvent) => {
-        if (!this.isActive) return;
+        if (!this.pianoRollState) return;
+        if (!this.pianoRollState.isMouseActive) return;
         if (event.key !== 'Backspace' && event.key !== 'Delete') return;
         if (isEditableTarget(event.target)) return;
 
-        const section = this._section;
+        const section = this.pianoRollState.sectionData?.section;
         if (!section) return;
         const notes = section.notes;
-        if (!notes?.length || !this.selectedNotes.length) return;
+        if (!notes?.length || !this.pianoRollState.selectedNotes.length) return;
 
-        const toRemove = new Set(this.selectedNotes);
+        const toRemove = new Set(this.pianoRollState.selectedNotes);
         let removed = false;
         for (let index = notes.length - 1; index >= 0; index--) {
             if (toRemove.has(notes[index]!)) {
@@ -409,7 +339,7 @@ export class PianoRollMouseController {
         if (!removed) return;
 
         event.preventDefault();
-        this.clearSelection();
+        this.pianoRollState.clearSelection();
         this.sortSectionNotes(section);
         this.refreshPlayer();
     };
@@ -427,7 +357,8 @@ export class PianoRollMouseController {
     }
 
     private clampTickToSection(tick: number): number {
-        const section = this._section;
+        if (!this.pianoRollState) return this.snapTick(tick);
+        const section = this.pianoRollState.sectionData?.section;
         const snappedTick = this.snapTick(tick);
         if (!section) return snappedTick;
         const maxTick = Math.max(0, section.length - NOTE_SPAN);
@@ -442,28 +373,33 @@ export class PianoRollMouseController {
     }
 
     private tickFromPointer(event: PointerEvent): number {
-        const content = this.gridContent;
+        if (!this.pianoRollState) return 0;
+        const content = this.pianoRollState.gridContent;
         if (!content) return 0;
         const rect = content.getBoundingClientRect();
         const x = event.clientX - rect.left;
-        const rawTick = x / this._pxPerTick;
+        const rawTick = x / this.pianoRollState.pxPerTick;
         return this.snapTick(rawTick);
     }
 
     private keyFromPointer(event: PointerEvent): number {
-        const content = this.gridContent;
-        if (!content) return this._keyRange.max;
+        if (!this.pianoRollState) return 87;
+        const content = this.pianoRollState.gridContent;
+        const keyRange = this.pianoRollState.keyRange;
+        const keyHeight = this.pianoRollState.keyHeight;
+        if (!content) return keyRange.max;
         const rect = content.getBoundingClientRect();
         const relativeY = event.clientY - rect.top;
-        const rawRow = Math.floor(relativeY / this._keyHeight);
-        const keyCount = Math.max(1, this._keyRange.max - this._keyRange.min + 1);
+        const rawRow = Math.floor(relativeY / keyHeight);
+        const keyCount = Math.max(1, keyRange.max - keyRange.min + 1);
         const clampedRow = Math.min(Math.max(rawRow, 0), Math.max(0, keyCount - 1));
-        const key = this._keyRange.max - clampedRow;
+        const key = keyRange.max - clampedRow;
         return Math.min(87, Math.max(0, key));
     }
 
     private findNoteAt(tick: number, key: number): Note | null {
-        const section = this._section;
+        if (!this.pianoRollState) return null;
+        const section = this.pianoRollState.sectionData?.section;
         if (!section) return null;
         for (const note of section.notes) {
             if (note.key !== key) continue;
@@ -474,132 +410,15 @@ export class PianoRollMouseController {
         return null;
     }
 
-    private selectNotes(notes: Note[]) {
-        const seen = new Set<Note>();
-        const filtered: Note[] = [];
-        for (const note of notes) {
-            if (!note || seen.has(note)) continue;
-            seen.add(note);
-            filtered.push(note);
-        }
-        const current = this.selectedNotes;
-        if (current.length === filtered.length) {
-            let changed = false;
-            for (let index = 0; index < current.length; index++) {
-                if (current[index] !== filtered[index]) {
-                    changed = true;
-                    break;
-                }
-            }
-            if (!changed) {
-                return;
-            }
-        }
-        this.selectedNotes = filtered;
-    }
-
-    private clearSelection() {
-        if (this.selectedNotes.length) {
-            this.selectedNotes = [];
-        }
-    }
-
-    private syncSelectedNotes() {
-        const section = this._section;
-        if (!section) {
-            this.selectedNotes = [];
-            this.selectionOverlayRect = null;
-            this.overlayPendingRect = null;
-            this.cancelOverlayFrame();
-            return;
-        }
-        const valid = new Set(section.notes);
-        const filtered: Note[] = [];
-        for (const note of this.selectedNotes) {
-            if (valid.has(note)) filtered.push(note);
-        }
-        if (filtered.length !== this.selectedNotes.length) {
-            this.selectedNotes = filtered;
-        } else {
-            // Compare existing order; avoid reassigning when unchanged
-            const current = this.selectedNotes;
-            let changed = false;
-            for (let index = 0; index < current.length; index++) {
-                if (current[index] !== filtered[index]) {
-                    changed = true;
-                    break;
-                }
-            }
-            if (changed) {
-                this.selectedNotes = filtered;
-            }
-        }
-    }
+    // Selection methods now handled by pianoRollState
 
     private refreshPlayer() {
         player.refreshIndexes();
     }
 
     private updateSelectionOverlayRect() {
-        // Never show selection overlay in pen mode
-        if (this._pointerMode === 'pen') {
-            this.queueOverlayRect(null);
-            return;
-        }
-
-        const box = this.selectionBox;
-        if (!box) {
-            this.queueOverlayRect(null);
-            return;
-        }
-
-        const px = this._pxPerTick > 0 ? this._pxPerTick : 1;
-        const tickStart = Math.min(box.startTick, box.currentTick);
-        const tickEnd = Math.max(box.startTick, box.currentTick) + NOTE_SPAN;
-        const left = Math.round(tickStart * px);
-        const right = Math.round(tickEnd * px);
-
-        const keyTop = Math.max(box.startKey, box.currentKey);
-        const keyBottom = Math.min(box.startKey, box.currentKey);
-        const top = (this._keyRange.max - keyTop) * this._keyHeight;
-        const bottom = (this._keyRange.max - keyBottom + 1) * this._keyHeight;
-
-        this.queueOverlayRect({
-            left: Math.min(left, right),
-            top: Math.min(top, bottom),
-            width: Math.max(1, Math.abs(right - left)),
-            height: Math.max(1, Math.abs(bottom - top))
-        });
-    }
-
-    private queueOverlayRect(rect: OverlayRect | null) {
-        if (
-            typeof globalThis === 'undefined' ||
-            typeof globalThis.requestAnimationFrame !== 'function'
-        ) {
-            this.selectionOverlayRect = rect;
-            return;
-        }
-
-        this.overlayPendingRect = rect;
-        if (this.overlayFrameId !== null) return;
-
-        this.overlayFrameId = globalThis.requestAnimationFrame(() => {
-            this.selectionOverlayRect = this.overlayPendingRect;
-            this.overlayFrameId = null;
-        });
-    }
-
-    private cancelOverlayFrame() {
-        if (this.overlayFrameId === null) return;
-        if (
-            typeof globalThis !== 'undefined' &&
-            typeof globalThis.cancelAnimationFrame === 'function'
-        ) {
-            globalThis.cancelAnimationFrame(this.overlayFrameId);
-        }
-        this.overlayFrameId = null;
-        this.overlayPendingRect = null;
+        if (!this.pianoRollState) return;
+        // Overlay rendering now handled by pianoRollState
     }
 }
 

--- a/src/lib/piano-roll-mouse.svelte.ts
+++ b/src/lib/piano-roll-mouse.svelte.ts
@@ -1,0 +1,424 @@
+import { PointerMode } from '$lib/editor-state.svelte';
+import { player } from '$lib/playback.svelte';
+import type { Note, NoteSection } from '$lib/types';
+
+export type PianoRollPointerMode = PointerMode.Normal | 'pen';
+export type KeyRange = { min: number; max: number };
+
+type SelectionBox = {
+    startTick: number;
+    startKey: number;
+    currentTick: number;
+    currentKey: number;
+};
+
+type DragContext = {
+    notes: Note[];
+    original: Map<Note, { tick: number; key: number }>;
+    minTick: number;
+    maxTick: number;
+    minKey: number;
+    maxKey: number;
+    startTick: number;
+    startKey: number;
+    pointerId: number;
+    moved: boolean;
+};
+
+type SelectionContext = { pointerId: number; startTick: number; startKey: number } | null;
+
+const NOTE_SPAN = 1;
+const DEFAULT_NOTE_VELOCITY = 100;
+const DEFAULT_NOTE_PITCH = 0;
+
+function isEditableTarget(target: EventTarget | null): boolean {
+    if (!(target instanceof HTMLElement)) return false;
+    const tag = target.tagName;
+    return target.isContentEditable || tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT';
+}
+
+export class PianoRollMouseController {
+    // Public reactive state
+    selectedNotes = $state<Note[]>([]);
+    selectionBox = $state<SelectionBox | null>(null);
+    pointerMode = $state<PianoRollPointerMode>(PointerMode.Normal);
+    isActive = $state(false);
+
+    gridContent = $state<HTMLDivElement | null>(null);
+
+    private _pxPerTick = 1;
+    private _keyRange: KeyRange = { min: 0, max: 87 };
+    private _keyHeight = 20;
+
+    private _section: NoteSection | null = null;
+
+    private dragContext: DragContext | null = null;
+    private selectionContext: SelectionContext = null;
+
+    setPointerMode = (mode: PianoRollPointerMode) => {
+        this.pointerMode = mode;
+        if (mode !== PointerMode.Normal) {
+            this.selectionBox = null;
+            this.selectionContext = null;
+            this.dragContext = null;
+        }
+    };
+
+    setActive = (active: boolean) => {
+        this.isActive = active;
+        if (!active) {
+            this.clearSelection();
+            this.selectionBox = null;
+            this.dragContext = null;
+            this.selectionContext = null;
+        }
+    };
+
+    setGridContent = (element: HTMLDivElement | null) => {
+        this.gridContent = element;
+    };
+
+    setSection = (section: NoteSection | null) => {
+        this._section = section;
+        this.syncSelectedNotes();
+    };
+
+    updateGeometry = ({
+        pxPerTick,
+        keyRange,
+        keyHeight
+    }: {
+        pxPerTick: number;
+        keyRange: KeyRange;
+        keyHeight: number;
+    }) => {
+        this._pxPerTick = pxPerTick > 0 ? pxPerTick : 1;
+        this._keyRange = keyRange;
+        this._keyHeight = keyHeight;
+    };
+
+    handleBackgroundPointerDown = (event: PointerEvent) => {
+        if (event.button !== 0) return;
+        event.preventDefault();
+
+        const section = this._section;
+        const grid = this.gridContent;
+        const pointerMode = this.pointerMode;
+
+        const tick = this.clampTickToSection(this.tickFromPointer(event));
+        const key = this.keyFromPointer(event);
+
+        if (pointerMode === PointerMode.Normal) {
+            this.selectionContext = { pointerId: event.pointerId, startTick: tick, startKey: key };
+            this.selectionBox = {
+                startTick: tick,
+                startKey: key,
+                currentTick: tick,
+                currentKey: key
+            };
+            this.clearSelection();
+        } else if (pointerMode === 'pen') {
+            if (!section) return;
+            const existing = this.findNoteAt(tick, key);
+            if (existing) {
+                this.selectNotes([existing]);
+            } else {
+                const newNote: Note = {
+                    tick,
+                    key,
+                    velocity: DEFAULT_NOTE_VELOCITY,
+                    pitch: DEFAULT_NOTE_PITCH
+                };
+                section.notes.push(newNote);
+                this.sortSectionNotes(section);
+                this.selectNotes([newNote]);
+                this.refreshPlayer();
+            }
+        }
+
+        grid?.setPointerCapture(event.pointerId);
+    };
+
+    handleNotePointerDown = (note: Note, event: PointerEvent) => {
+        if (event.button !== 0) return;
+        event.preventDefault();
+        event.stopPropagation();
+
+        const section = this._section;
+        if (!section) return;
+
+        if (this.pointerMode === PointerMode.Normal) {
+            if (!this.selectedNotes.includes(note)) {
+                this.selectNotes([note]);
+            }
+
+            const notes = [...this.selectedNotes];
+            const original = new Map<Note, { tick: number; key: number }>();
+            let minTick = Number.POSITIVE_INFINITY;
+            let maxTick = Number.NEGATIVE_INFINITY;
+            let minKey = Number.POSITIVE_INFINITY;
+            let maxKey = Number.NEGATIVE_INFINITY;
+
+            for (const n of notes) {
+                this.ensureNoteTick(n);
+                original.set(n, {
+                    tick: n.tick,
+                    key: n.key
+                });
+                if (n.tick < minTick) minTick = n.tick;
+                if (n.tick > maxTick) maxTick = n.tick;
+                if (n.key < minKey) minKey = n.key;
+                if (n.key > maxKey) maxKey = n.key;
+            }
+
+            this.dragContext = {
+                notes,
+                original,
+                minTick: Number.isFinite(minTick) ? minTick : 0,
+                maxTick: Number.isFinite(maxTick) ? maxTick : 0,
+                minKey: Number.isFinite(minKey) ? minKey : 0,
+                maxKey: Number.isFinite(maxKey) ? maxKey : 0,
+                startTick: this.tickFromPointer(event),
+                startKey: this.keyFromPointer(event),
+                pointerId: event.pointerId,
+                moved: false
+            };
+
+            this.gridContent?.setPointerCapture(event.pointerId);
+        } else if (this.pointerMode === 'pen') {
+            this.selectNotes([note]);
+        }
+    };
+
+    handleWindowPointerMove = (event: PointerEvent) => {
+        const section = this._section;
+        if (!section) return;
+
+        if (
+            this.dragContext &&
+            this.dragContext.pointerId === event.pointerId &&
+            this.pointerMode === PointerMode.Normal
+        ) {
+            const tick = this.tickFromPointer(event);
+            const key = this.keyFromPointer(event);
+            let tickDelta = tick - this.dragContext.startTick;
+            let keyDelta = key - this.dragContext.startKey;
+
+            const minTickDelta = -this.dragContext.minTick;
+            const maxTickAllowed = Math.max(0, section.length - NOTE_SPAN);
+            const maxTickDelta = maxTickAllowed - this.dragContext.maxTick;
+            tickDelta = Math.min(Math.max(tickDelta, minTickDelta), maxTickDelta);
+
+            const minKeyDelta = -this.dragContext.minKey;
+            const maxKeyDelta = 87 - this.dragContext.maxKey;
+            keyDelta = Math.min(Math.max(keyDelta, minKeyDelta), maxKeyDelta);
+
+            for (const note of this.dragContext.notes) {
+                const orig = this.dragContext.original.get(note);
+                if (!orig) continue;
+                const nextTick = this.clampTickToSection(orig.tick + tickDelta);
+                note.tick = nextTick;
+                note.key = Math.min(87, Math.max(0, orig.key + keyDelta));
+            }
+
+            this.dragContext.moved ||= tickDelta !== 0 || keyDelta !== 0;
+        }
+
+        if (
+            this.selectionContext &&
+            this.selectionContext.pointerId === event.pointerId &&
+            this.pointerMode === PointerMode.Normal
+        ) {
+            const tick = this.tickFromPointer(event);
+            const key = this.keyFromPointer(event);
+            this.selectionBox = {
+                startTick: this.selectionContext.startTick,
+                startKey: this.selectionContext.startKey,
+                currentTick: tick,
+                currentKey: key
+            };
+
+            const minTick = Math.min(this.selectionContext.startTick, tick);
+            const maxTick = Math.max(this.selectionContext.startTick, tick + NOTE_SPAN);
+            const minKey = Math.min(this.selectionContext.startKey, key);
+            const maxKey = Math.max(this.selectionContext.startKey, key);
+
+            const notes: Note[] = [];
+            for (const n of section.notes) {
+                const start = n.tick;
+                const end = start + NOTE_SPAN;
+                const overlapsTick = end > minTick && start < maxTick;
+                const withinKey = n.key >= minKey && n.key <= maxKey;
+                if (overlapsTick && withinKey) notes.push(n);
+            }
+            this.selectNotes(notes);
+        }
+    };
+
+    handleWindowPointerUp = (event: PointerEvent) => {
+        const section = this._section;
+
+        if (this.dragContext && this.dragContext.pointerId === event.pointerId) {
+            if (this.dragContext.moved && section) {
+                this.sortSectionNotes(section);
+                this.refreshPlayer();
+            }
+            this.dragContext = null;
+        }
+
+        if (this.selectionContext && this.selectionContext.pointerId === event.pointerId) {
+            const box = this.selectionBox;
+            if (
+                box &&
+                box.startTick === box.currentTick &&
+                box.startKey === box.currentKey &&
+                this.pointerMode === PointerMode.Normal
+            ) {
+                this.clearSelection();
+            }
+            this.selectionContext = null;
+            this.selectionBox = null;
+        }
+
+        const grid = this.gridContent;
+        if (grid) {
+            try {
+                if (grid.hasPointerCapture(event.pointerId)) {
+                    grid.releasePointerCapture(event.pointerId);
+                }
+            } catch {
+                // ignore
+            }
+        }
+    };
+
+    handleWindowPointerCancel = (event: PointerEvent) => {
+        this.handleWindowPointerUp(event);
+    };
+
+    handleWindowKeyDown = (event: KeyboardEvent) => {
+        if (!this.isActive) return;
+        if (event.key !== 'Backspace' && event.key !== 'Delete') return;
+        if (isEditableTarget(event.target)) return;
+
+        const section = this._section;
+        if (!section) return;
+        const notes = section.notes;
+        if (!notes?.length || !this.selectedNotes.length) return;
+
+        const toRemove = new Set(this.selectedNotes);
+        let removed = false;
+        for (let index = notes.length - 1; index >= 0; index--) {
+            if (toRemove.has(notes[index]!)) {
+                notes.splice(index, 1);
+                removed = true;
+            }
+        }
+
+        if (!removed) return;
+
+        event.preventDefault();
+        this.clearSelection();
+        this.sortSectionNotes(section);
+        this.refreshPlayer();
+    };
+
+    private snapTick(value: number): number {
+        if (!Number.isFinite(value)) return 0;
+        return Math.max(0, Math.round(value));
+    }
+
+    private ensureNoteTick(note: Note) {
+        const snapped = this.snapTick(note.tick);
+        if (note.tick !== snapped) {
+            note.tick = snapped;
+        }
+    }
+
+    private clampTickToSection(tick: number): number {
+        const section = this._section;
+        const snappedTick = this.snapTick(tick);
+        if (!section) return snappedTick;
+        const maxTick = Math.max(0, section.length - NOTE_SPAN);
+        return Math.min(Math.max(0, snappedTick), maxTick);
+    }
+
+    private sortSectionNotes(section: NoteSection) {
+        section.notes.sort((a, b) => {
+            if (a.tick !== b.tick) return a.tick - b.tick;
+            return a.key - b.key;
+        });
+    }
+
+    private tickFromPointer(event: PointerEvent): number {
+        const content = this.gridContent;
+        if (!content) return 0;
+        const rect = content.getBoundingClientRect();
+        const x = event.clientX - rect.left;
+        const rawTick = x / this._pxPerTick;
+        return this.snapTick(rawTick);
+    }
+
+    private keyFromPointer(event: PointerEvent): number {
+        const content = this.gridContent;
+        if (!content) return this._keyRange.max;
+        const rect = content.getBoundingClientRect();
+        const relativeY = event.clientY - rect.top;
+        const rawRow = Math.floor(relativeY / this._keyHeight);
+        const keyCount = Math.max(1, this._keyRange.max - this._keyRange.min + 1);
+        const clampedRow = Math.min(Math.max(rawRow, 0), Math.max(0, keyCount - 1));
+        const key = this._keyRange.max - clampedRow;
+        return Math.min(87, Math.max(0, key));
+    }
+
+    private findNoteAt(tick: number, key: number): Note | null {
+        const section = this._section;
+        if (!section) return null;
+        for (const note of section.notes) {
+            if (note.key !== key) continue;
+            const start = note.tick;
+            const end = start + NOTE_SPAN;
+            if (tick >= start && tick < end) return note;
+        }
+        return null;
+    }
+
+    private selectNotes(notes: Note[]) {
+        const seen = new Set<Note>();
+        const filtered: Note[] = [];
+        for (const note of notes) {
+            if (!note || seen.has(note)) continue;
+            seen.add(note);
+            filtered.push(note);
+        }
+        this.selectedNotes = filtered;
+    }
+
+    private clearSelection() {
+        if (this.selectedNotes.length) {
+            this.selectedNotes = [];
+        }
+    }
+
+    private syncSelectedNotes() {
+        const section = this._section;
+        if (!section) {
+            this.selectedNotes = [];
+            return;
+        }
+        const valid = new Set(section.notes);
+        const filtered: Note[] = [];
+        for (const note of this.selectedNotes) {
+            if (valid.has(note)) filtered.push(note);
+        }
+        if (filtered.length !== this.selectedNotes.length) {
+            this.selectedNotes = filtered;
+        }
+    }
+
+    private refreshPlayer() {
+        player.refreshIndexes();
+    }
+}
+
+export const pianoRollMouse = new PianoRollMouseController();

--- a/src/lib/piano-roll-mouse.svelte.ts
+++ b/src/lib/piano-roll-mouse.svelte.ts
@@ -18,6 +18,7 @@ interface PianoRollState {
     isMouseActive: boolean;
     selectNotes: (notes: Note[]) => void;
     clearSelection: () => void;
+    updateSelectionOverlayRect: () => void;
 }
 export type KeyRange = { min: number; max: number };
 
@@ -417,8 +418,7 @@ export class PianoRollMouseController {
     }
 
     private updateSelectionOverlayRect() {
-        if (!this.pianoRollState) return;
-        // Overlay rendering now handled by pianoRollState
+        this.pianoRollState?.updateSelectionOverlayRect();
     }
 }
 

--- a/src/lib/piano-roll-state.svelte.ts
+++ b/src/lib/piano-roll-state.svelte.ts
@@ -1,0 +1,290 @@
+import { editorState, PointerMode } from '$lib/editor-state.svelte';
+import { LoopMode, player } from '$lib/playback.svelte';
+import { pianoRollMouse, type KeyRange, type PianoRollPointerMode } from '$lib/piano-roll-mouse.svelte';
+import type { Note, NoteChannel, NoteSection } from '$lib/types';
+
+export type PianoRollContext = {
+    channel: NoteChannel;
+    section: NoteSection;
+    channelIndex: number;
+    sectionIndex: number;
+};
+
+const DEFAULT_KEY_RANGE: KeyRange = { min: 33, max: 57 };
+const NOTE_SPAN = 1;
+
+function computeKeyRange(notes: Note[] | undefined): KeyRange {
+    if (!notes || notes.length === 0) return DEFAULT_KEY_RANGE;
+    let min = Math.min(...notes.map((n) => n.key));
+    let max = Math.max(...notes.map((n) => n.key));
+    min = Math.max(0, min - 2);
+    max = Math.min(87, max + 2);
+    if (max - min < 12) {
+        const pad = Math.ceil((12 - (max - min)) / 2);
+        min = Math.max(0, min - pad);
+        max = Math.min(87, max + pad);
+    }
+    return { min, max };
+}
+
+export class PianoRollState {
+    sheetOpen = $state(false);
+    pointerMode = $state<PianoRollPointerMode>(PointerMode.Normal);
+
+    gridScroller = $state<HTMLDivElement | null>(null);
+    keysScroller = $state<HTMLDivElement | null>(null);
+    gridContent = $state<HTMLDivElement | null>(null);
+    gridScrollLeft = $state(0);
+
+    keyHeight = 20;
+    noteLaneHeight = Math.max(8, this.keyHeight - 6);
+
+    pianoRollTarget = $derived(editorState.pianoRollTarget);
+
+    sectionData = $derived.by<PianoRollContext | null>(() => {
+        const target = this.pianoRollTarget;
+        if (!target) return null;
+        const channel = player.song?.channels?.[target.channelIndex];
+        if (!channel || channel.kind !== 'note') return null;
+        const section = channel.sections?.[target.sectionIndex];
+        if (!section) return null;
+        return {
+            channel,
+            section,
+            channelIndex: target.channelIndex,
+            sectionIndex: target.sectionIndex
+        } satisfies PianoRollContext;
+    });
+
+    ticksPerBeat = $derived(Math.max(1, editorState.ticksPerBeat));
+    beatsPerBar = $derived(Math.max(1, editorState.beatsPerBar));
+    pxPerTick = $derived(editorState.ticksPerBeat > 0 ? editorState.pxPerBeat / editorState.ticksPerBeat : 0);
+
+    keyRange = $derived.by<KeyRange>(() => computeKeyRange(this.sectionData?.section?.notes));
+    keyCount = $derived.by(() => this.keyRange.max - this.keyRange.min + 1);
+    gridHeight = $derived(Math.max(1, this.keyCount) * this.keyHeight);
+
+    rawGridWidth = $derived.by(() => {
+        const section = this.sectionData?.section;
+        if (!section) return 0;
+        const pxTick = this.pxPerTick > 0 ? this.pxPerTick : 1;
+        const lengthPx = section.length * pxTick;
+        const minWidth = Math.max(640, this.beatsPerBar * this.ticksPerBeat * pxTick);
+        return Math.max(minWidth, Math.ceil(lengthPx));
+    });
+
+    barWidth = $derived(Math.max(1, editorState.barWidth));
+    totalBars = $derived.by(() => {
+        if (this.barWidth <= 0) return 1;
+        return Math.max(1, Math.ceil(this.rawGridWidth / this.barWidth));
+    });
+    contentWidth = $derived(this.totalBars * this.barWidth);
+
+    notesToRender = $derived.by(
+        () => {
+            const section = this.sectionData?.section;
+            if (!section) {
+                return [] as Array<{
+                    id: string;
+                    left: number;
+                    top: number;
+                    width: number;
+                    height: number;
+                    note: Note;
+                    selected: boolean;
+                }>;
+            }
+
+            const range = this.keyRange;
+            const pxTickValue = this.pxPerTick > 0 ? this.pxPerTick : 1;
+            const laneHeight = this.noteLaneHeight;
+            const offset = (this.keyHeight - laneHeight) / 2;
+            const selectedSet = new Set(pianoRollMouse.selectedNotes);
+
+            return (section.notes ?? []).map((note, index) => {
+                const top = (range.max - note.key) * this.keyHeight + offset;
+                const width = Math.max(8, Math.round(NOTE_SPAN * pxTickValue));
+                const left = Math.max(0, Math.round(note.tick * pxTickValue));
+                const id = `${section.startingTick + note.tick}:${note.key}:${index}`;
+                return {
+                    id,
+                    left,
+                    top,
+                    width,
+                    height: laneHeight,
+                    note,
+                    selected: selectedSet.has(note)
+                };
+            });
+        }
+    );
+
+    sectionBeatLength = $derived.by(() => {
+        const section = this.sectionData?.section;
+        if (!section) return 0;
+        return +(section.length / this.ticksPerBeat).toFixed(2);
+    });
+
+    sectionStartTick = $derived(this.sectionData?.section?.startingTick ?? 0);
+    sectionEndTick = $derived.by(() => this.sectionStartTick + (this.sectionData?.section?.length ?? 0));
+    cursorTick = $derived(player.currentTick);
+    cursorVisible = $derived.by(() => this.cursorTick >= this.sectionStartTick && this.cursorTick <= this.sectionEndTick);
+
+    isPlaying = $derived(player.isPlaying);
+
+    positionBar = $derived(String(player.currentBar + 1).padStart(3, '0'));
+    positionBeat = $derived(String(player.currentBeat + 1).padStart(2, '0'));
+    positionTickInBeat = $derived(String((player.currentTick % player.ticksPerBeat) + 1).padStart(2, '0'));
+
+    loopModeButtonClass = $derived.by(() => {
+        switch (player.loopMode) {
+            case LoopMode.Selection:
+                return 'bg-purple-600 text-white hover:bg-purple-600/80 dark:hover:bg-purple-600/80 hover:text-white';
+            case LoopMode.Song:
+                return 'bg-amber-500 text-white hover:bg-amber-500/80 dark:hover:bg-amber-500/80 hover:text-white';
+            case LoopMode.Off:
+            default:
+                return '';
+        }
+    });
+
+    loopModeLabel = $derived.by(() => {
+        switch (player.loopMode) {
+            case LoopMode.Selection:
+                return 'Loop: Selection';
+            case LoopMode.Song:
+                return 'Loop: Song';
+            case LoopMode.Off:
+            default:
+                return 'Loop: Off';
+        }
+    });
+
+    constructor() {
+        $effect(() => {
+            this.sheetOpen = this.pianoRollTarget !== null;
+        });
+
+        $effect(() => {
+            if (!this.sheetOpen && this.pianoRollTarget) {
+                editorState.closePianoRoll();
+            }
+        });
+
+        $effect(() => {
+            if (this.pianoRollTarget && !this.sectionData) {
+                editorState.closePianoRoll();
+                this.sheetOpen = false;
+            }
+        });
+
+        $effect(() => {
+            const grid = this.gridScroller;
+            if (!grid) return;
+            if (Math.abs(grid.scrollLeft - this.gridScrollLeft) > 1) {
+                grid.scrollLeft = this.gridScrollLeft;
+            }
+        });
+
+        $effect(() => {
+            pianoRollMouse.setGridContent(this.gridContent);
+        });
+
+        $effect(() => {
+            pianoRollMouse.setSection(this.sectionData?.section ?? null);
+        });
+
+        $effect(() => {
+            pianoRollMouse.updateGeometry({
+                pxPerTick: this.pxPerTick > 0 ? this.pxPerTick : 1,
+                keyRange: this.keyRange,
+                keyHeight: this.keyHeight
+            });
+        });
+
+        $effect(() => {
+            pianoRollMouse.setActive(this.sheetOpen);
+        });
+
+        $effect(() => {
+            pianoRollMouse.setPointerMode(this.pointerMode);
+        });
+
+        $effect(() => {
+            this.gridScrollLeft = this.gridScroller?.scrollLeft ?? 0;
+        });
+
+        $effect(() => {
+            if (!this.sheetOpen) {
+                this.pointerMode = PointerMode.Normal;
+            }
+        });
+    }
+
+    handleGridScroll = () => {
+        const grid = this.gridScroller;
+        const keys = this.keysScroller;
+        if (!grid) return;
+        const { scrollTop, scrollLeft } = grid;
+        this.gridScrollLeft = scrollLeft;
+        if (keys && Math.abs(keys.scrollTop - scrollTop) > 1) {
+            keys.scrollTop = scrollTop;
+        }
+    };
+
+    handleRulerScrollLeft(left: number) {
+        const grid = this.gridScroller;
+        if (grid && Math.abs(grid.scrollLeft - left) > 1) {
+            grid.scrollLeft = left;
+        }
+        this.gridScrollLeft = left;
+    }
+
+    keyNumberToInfo(key: number) {
+        const names = ['A', 'A#', 'B', 'C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#'];
+        const noteName = names[key % 12];
+        const octave = Math.floor((key + 9) / 12);
+        const isBlack = noteName.includes('#');
+        return { label: `${noteName}${octave}`, isBlack };
+    }
+
+    keyRows = $derived.by(() => {
+        const rows: Array<{ key: number; label: string; isBlack: boolean }> = [];
+        for (let key = this.keyRange.max; key >= this.keyRange.min; key--) {
+            const info = this.keyNumberToInfo(key);
+            rows.push({ key, ...info });
+        }
+        return rows;
+    });
+
+    rewind = () => player.setBarBeat(0, 0);
+
+    togglePlay = () => (player.isPlaying ? player.pause() : player.resume());
+
+    cycleLoop = () => {
+        switch (player.loopMode) {
+            case LoopMode.Off:
+                player.setLoopMode(LoopMode.Song);
+                break;
+            case LoopMode.Song:
+                player.setLoopMode(LoopMode.Selection);
+                break;
+            case LoopMode.Selection:
+            default:
+                player.setLoopMode(LoopMode.Off);
+                break;
+        }
+    };
+
+    setPointerMode(mode: PianoRollPointerMode) {
+        this.pointerMode = mode;
+    }
+
+    pointerButtonClass(mode: PianoRollPointerMode) {
+        return this.pointerMode === mode
+            ? 'bg-indigo-600 text-white hover:bg-indigo-600/80 dark:hover:bg-indigo-600/80 hover:text-white'
+            : '';
+    }
+}
+
+export const pianoRollState = new PianoRollState();

--- a/src/lib/piano-roll-state.svelte.ts
+++ b/src/lib/piano-roll-state.svelte.ts
@@ -1,9 +1,5 @@
 import { editorState, PointerMode } from '$lib/editor-state.svelte';
-import {
-    pianoRollMouse,
-    type KeyRange,
-    type PianoRollPointerMode
-} from '$lib/piano-roll-mouse.svelte';
+import { type KeyRange, type PianoRollPointerMode } from '$lib/piano-roll-mouse.svelte';
 import { LoopMode, player } from '$lib/playback.svelte';
 import type { Note, NoteChannel, NoteSection } from '$lib/types';
 
@@ -43,12 +39,27 @@ export class PianoRollState {
 
     // Mouse state - moved from piano-roll-mouse.svelte.ts
     selectedNotes = $state<Note[]>([]);
-    selectionBox = $state<{ startTick: number; startKey: number; currentTick: number; currentKey: number } | null>(null);
-    selectionOverlayRect = $state<{ left: number; top: number; width: number; height: number } | null>(null);
+    selectionBox = $state<{
+        startTick: number;
+        startKey: number;
+        currentTick: number;
+        currentKey: number;
+    } | null>(null);
+    selectionOverlayRect = $state<{
+        left: number;
+        top: number;
+        width: number;
+        height: number;
+    } | null>(null);
     isMouseActive = $state(false);
 
     // Overlay optimization
-    private overlayPendingRect: { left: number; top: number; width: number; height: number } | null = null;
+    private overlayPendingRect: {
+        left: number;
+        top: number;
+        width: number;
+        height: number;
+    } | null = null;
     private overlayFrameId: number | null = null;
 
     keyHeight = 20;
@@ -306,7 +317,9 @@ export class PianoRollState {
         });
     }
 
-    private queueOverlayRect(rect: { left: number; top: number; width: number; height: number } | null) {
+    private queueOverlayRect(
+        rect: { left: number; top: number; width: number; height: number } | null
+    ) {
         if (
             typeof globalThis === 'undefined' ||
             typeof globalThis.requestAnimationFrame !== 'function'

--- a/src/lib/piano-roll-state.svelte.ts
+++ b/src/lib/piano-roll-state.svelte.ts
@@ -234,6 +234,7 @@ export class PianoRollState {
     };
 
     setPointerMode(mode: PianoRollPointerMode) {
+        if (this.pointerMode === mode) return;
         this.pointerMode = mode;
     }
 

--- a/src/lib/piano-roll-state.svelte.ts
+++ b/src/lib/piano-roll-state.svelte.ts
@@ -130,6 +130,10 @@ export class PianoRollState {
     });
 
     sectionStartTick = $derived(this.sectionData?.section?.startingTick ?? 0);
+    sectionStartBar = $derived.by(() => {
+        if (!this.sectionData) return 0;
+        return player.getBarAtTick(this.sectionStartTick);
+    });
     sectionEndTick = $derived.by(
         () => this.sectionStartTick + (this.sectionData?.section?.length ?? 0)
     );

--- a/src/lib/piano-roll-state.svelte.ts
+++ b/src/lib/piano-roll-state.svelte.ts
@@ -39,6 +39,7 @@ export class PianoRollState {
     keysScroller = $state<HTMLDivElement | null>(null);
     gridContent = $state<HTMLDivElement | null>(null);
     gridScrollLeft = $state(0);
+    gridScrollTop = $state(0);
 
     keyHeight = 20;
     noteLaneHeight = Math.max(8, this.keyHeight - 6);
@@ -182,6 +183,7 @@ export class PianoRollState {
         if (!grid) return;
         const { scrollTop, scrollLeft } = grid;
         this.gridScrollLeft = scrollLeft;
+        this.gridScrollTop = scrollTop;
         if (keys && Math.abs(keys.scrollTop - scrollTop) > 1) {
             keys.scrollTop = scrollTop;
         }

--- a/src/lib/piano-roll-state.svelte.ts
+++ b/src/lib/piano-roll-state.svelte.ts
@@ -1,6 +1,10 @@
 import { editorState, PointerMode } from '$lib/editor-state.svelte';
+import {
+    pianoRollMouse,
+    type KeyRange,
+    type PianoRollPointerMode
+} from '$lib/piano-roll-mouse.svelte';
 import { LoopMode, player } from '$lib/playback.svelte';
-import { pianoRollMouse, type KeyRange, type PianoRollPointerMode } from '$lib/piano-roll-mouse.svelte';
 import type { Note, NoteChannel, NoteSection } from '$lib/types';
 
 export type PianoRollContext = {
@@ -58,7 +62,9 @@ export class PianoRollState {
 
     ticksPerBeat = $derived(Math.max(1, editorState.ticksPerBeat));
     beatsPerBar = $derived(Math.max(1, editorState.beatsPerBar));
-    pxPerTick = $derived(editorState.ticksPerBeat > 0 ? editorState.pxPerBeat / editorState.ticksPerBeat : 0);
+    pxPerTick = $derived(
+        editorState.ticksPerBeat > 0 ? editorState.pxPerBeat / editorState.ticksPerBeat : 0
+    );
 
     keyRange = $derived.by<KeyRange>(() => computeKeyRange(this.sectionData?.section?.notes));
     keyCount = $derived.by(() => this.keyRange.max - this.keyRange.min + 1);
@@ -80,44 +86,42 @@ export class PianoRollState {
     });
     contentWidth = $derived(this.totalBars * this.barWidth);
 
-    notesToRender = $derived.by(
-        () => {
-            const section = this.sectionData?.section;
-            if (!section) {
-                return [] as Array<{
-                    id: string;
-                    left: number;
-                    top: number;
-                    width: number;
-                    height: number;
-                    note: Note;
-                    selected: boolean;
-                }>;
-            }
-
-            const range = this.keyRange;
-            const pxTickValue = this.pxPerTick > 0 ? this.pxPerTick : 1;
-            const laneHeight = this.noteLaneHeight;
-            const offset = (this.keyHeight - laneHeight) / 2;
-            const selectedSet = new Set(pianoRollMouse.selectedNotes);
-
-            return (section.notes ?? []).map((note, index) => {
-                const top = (range.max - note.key) * this.keyHeight + offset;
-                const width = Math.max(8, Math.round(NOTE_SPAN * pxTickValue));
-                const left = Math.max(0, Math.round(note.tick * pxTickValue));
-                const id = `${section.startingTick + note.tick}:${note.key}:${index}`;
-                return {
-                    id,
-                    left,
-                    top,
-                    width,
-                    height: laneHeight,
-                    note,
-                    selected: selectedSet.has(note)
-                };
-            });
+    notesToRender = $derived.by(() => {
+        const section = this.sectionData?.section;
+        if (!section) {
+            return [] as Array<{
+                id: string;
+                left: number;
+                top: number;
+                width: number;
+                height: number;
+                note: Note;
+                selected: boolean;
+            }>;
         }
-    );
+
+        const range = this.keyRange;
+        const pxTickValue = this.pxPerTick > 0 ? this.pxPerTick : 1;
+        const laneHeight = this.noteLaneHeight;
+        const offset = (this.keyHeight - laneHeight) / 2;
+        const selectedSet = new Set(pianoRollMouse.selectedNotes);
+
+        return (section.notes ?? []).map((note, index) => {
+            const top = (range.max - note.key) * this.keyHeight + offset;
+            const width = Math.max(8, Math.round(NOTE_SPAN * pxTickValue));
+            const left = Math.max(0, Math.round(note.tick * pxTickValue));
+            const id = `${section.startingTick + note.tick}:${note.key}:${index}`;
+            return {
+                id,
+                left,
+                top,
+                width,
+                height: laneHeight,
+                note,
+                selected: selectedSet.has(note)
+            };
+        });
+    });
 
     sectionBeatLength = $derived.by(() => {
         const section = this.sectionData?.section;
@@ -126,15 +130,21 @@ export class PianoRollState {
     });
 
     sectionStartTick = $derived(this.sectionData?.section?.startingTick ?? 0);
-    sectionEndTick = $derived.by(() => this.sectionStartTick + (this.sectionData?.section?.length ?? 0));
+    sectionEndTick = $derived.by(
+        () => this.sectionStartTick + (this.sectionData?.section?.length ?? 0)
+    );
     cursorTick = $derived(player.currentTick);
-    cursorVisible = $derived.by(() => this.cursorTick >= this.sectionStartTick && this.cursorTick <= this.sectionEndTick);
+    cursorVisible = $derived.by(
+        () => this.cursorTick >= this.sectionStartTick && this.cursorTick <= this.sectionEndTick
+    );
 
     isPlaying = $derived(player.isPlaying);
 
     positionBar = $derived(String(player.currentBar + 1).padStart(3, '0'));
     positionBeat = $derived(String(player.currentBeat + 1).padStart(2, '0'));
-    positionTickInBeat = $derived(String((player.currentTick % player.ticksPerBeat) + 1).padStart(2, '0'));
+    positionTickInBeat = $derived(
+        String((player.currentTick % player.ticksPerBeat) + 1).padStart(2, '0')
+    );
 
     loopModeButtonClass = $derived.by(() => {
         switch (player.loopMode) {
@@ -160,66 +170,7 @@ export class PianoRollState {
         }
     });
 
-    constructor() {
-        $effect(() => {
-            this.sheetOpen = this.pianoRollTarget !== null;
-        });
-
-        $effect(() => {
-            if (!this.sheetOpen && this.pianoRollTarget) {
-                editorState.closePianoRoll();
-            }
-        });
-
-        $effect(() => {
-            if (this.pianoRollTarget && !this.sectionData) {
-                editorState.closePianoRoll();
-                this.sheetOpen = false;
-            }
-        });
-
-        $effect(() => {
-            const grid = this.gridScroller;
-            if (!grid) return;
-            if (Math.abs(grid.scrollLeft - this.gridScrollLeft) > 1) {
-                grid.scrollLeft = this.gridScrollLeft;
-            }
-        });
-
-        $effect(() => {
-            pianoRollMouse.setGridContent(this.gridContent);
-        });
-
-        $effect(() => {
-            pianoRollMouse.setSection(this.sectionData?.section ?? null);
-        });
-
-        $effect(() => {
-            pianoRollMouse.updateGeometry({
-                pxPerTick: this.pxPerTick > 0 ? this.pxPerTick : 1,
-                keyRange: this.keyRange,
-                keyHeight: this.keyHeight
-            });
-        });
-
-        $effect(() => {
-            pianoRollMouse.setActive(this.sheetOpen);
-        });
-
-        $effect(() => {
-            pianoRollMouse.setPointerMode(this.pointerMode);
-        });
-
-        $effect(() => {
-            this.gridScrollLeft = this.gridScroller?.scrollLeft ?? 0;
-        });
-
-        $effect(() => {
-            if (!this.sheetOpen) {
-                this.pointerMode = PointerMode.Normal;
-            }
-        });
-    }
+    constructor() {}
 
     handleGridScroll = () => {
         const grid = this.gridScroller;

--- a/src/lib/piano-roll-state.svelte.ts
+++ b/src/lib/piano-roll-state.svelte.ts
@@ -41,6 +41,12 @@ export class PianoRollState {
     gridScrollLeft = $state(0);
     gridScrollTop = $state(0);
 
+    // Mouse state - moved from piano-roll-mouse.svelte.ts
+    selectedNotes = $state<Note[]>([]);
+    selectionBox = $state<{ startTick: number; startKey: number; currentTick: number; currentKey: number } | null>(null);
+    selectionOverlayRect = $state<{ left: number; top: number; width: number; height: number } | null>(null);
+    isMouseActive = $state(false);
+
     keyHeight = 20;
     noteLaneHeight = Math.max(8, this.keyHeight - 6);
 
@@ -105,7 +111,7 @@ export class PianoRollState {
         const pxTickValue = this.pxPerTick > 0 ? this.pxPerTick : 1;
         const laneHeight = this.noteLaneHeight;
         const offset = (this.keyHeight - laneHeight) / 2;
-        const selectedSet = new Set(pianoRollMouse.selectedNotes);
+        const selectedSet = new Set(this.selectedNotes);
 
         return (section.notes ?? []).map((note, index) => {
             const top = (range.max - note.key) * this.keyHeight + offset;
@@ -236,6 +242,30 @@ export class PianoRollState {
     setPointerMode(mode: PianoRollPointerMode) {
         if (this.pointerMode === mode) return;
         this.pointerMode = mode;
+
+        // Clear selection state when changing modes
+        this.selectionBox = null;
+        this.selectionOverlayRect = null;
+
+        // In pen mode, clear selected notes
+        if (mode === 'pen') {
+            this.selectedNotes = [];
+        }
+    }
+
+    selectNotes(notes: Note[]) {
+        const seen = new Set<Note>();
+        const filtered: Note[] = [];
+        for (const note of notes) {
+            if (!note || seen.has(note)) continue;
+            seen.add(note);
+            filtered.push(note);
+        }
+        this.selectedNotes = filtered;
+    }
+
+    clearSelection() {
+        this.selectedNotes = [];
     }
 
     pointerButtonClass(mode: PianoRollPointerMode) {

--- a/src/lib/playback.svelte.ts
+++ b/src/lib/playback.svelte.ts
@@ -344,6 +344,13 @@ export class Player {
         return this.computeBarBeatAtTick(this._currentTick).beat;
     }
 
+    /**
+     * Get the bar number (0-based) at a specific tick.
+     */
+    getBarAtTick(tick: number): number {
+        return this.computeBarBeatAtTick(tick).bar;
+    }
+
     /** Current loop mode. */
     get loopMode() {
         return this._loopMode;


### PR DESCRIPTION
Summary
- Add a NotePianoRoll view to the editor with dblclick-to-open behavior for channel/section editing
- Introduce Sheet overlay component and standardize sheet styling/animation
- Make TimelineGrid configurable via props (contentWidth, scrollLeft, barWidth, totalBars, beatsPerBar, pxPerBeat) for reuse and decoupled rendering
- Add playback, loop and pointer-mode controls with tooltips in the piano roll header
- Add pen pointer mode plus robust selection, dragging and pen-drawing logic for note creation/editing
- Normalize and snap note tick/duration values to prevent fractional/invalid ticks
- Centralize pointer/mouse and piano-roll UI state into pianoRollState and piano-roll-mouse, removing duplicated local logic
- Extract selection overlay into a reusable component and add vertical scroll support plus RAF-backed batching for overlay updates
- Add keyboard Delete/Backspace handling to remove selected notes and refresh player indexes
- Multiple UI/UX refinements: auto-scroll playhead, zoom controls, px/beat display, mute/solo bindings, selected-note visuals, note-played highlight fade fixes, and misc styling/import cleanups

What changed
- New components: NotePianoRoll, Sheet overlay, SelectionRectangleOverlay
- New/shared state/modules: pianoRollState, piano-roll-mouse, piano-roll-mouse types and helpers
- TimelineGrid now supports optional layout props and derived fallbacks
- Playback controls, tooltips, and a reusable tooltipped snippet added to piano roll header
- Pen mode, selection box, drag/pen contexts and pointer utilities centralized and hardened
- Tick/duration snapping and ensureNote* helpers applied consistently before edits
- Overlay update queue (RAF) to reduce layout thrash
- Keyboard deletion support for selected notes

Notes for reviewers
- Focus on pianoRollState and piano-roll-mouse changes (ownership moved from component into shared state)
- Verify snapping/normalization logic and that no fractional tick values propagate
- Check selection overlay behavior with vertical scrolling and RAF batching
- Confirm playback and pointer-mode controls behave as expected in the header UI