### PR TITLE
feat(layout): add head metadata, favicon, and social tags

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -8,4 +8,34 @@
 
 <ModeWatcher />
 <Toaster />
+
+<svelte:head>
+    <link rel="icon" href="/noteblock.png" />
+    <title>Noteblock Studio Next</title>
+    <meta
+        name="description"
+        content="A modern, web-based music editor for Minecraft Note Block musics."
+    />
+
+    <!-- OpenGraph meta tags -->
+    <meta property="og:type" content="website" />
+    <meta property="og:title" content="Noteblock Studio Next" />
+    <meta
+        property="og:description"
+        content="A modern, web-based music editor for Minecraft Note Block musics."
+    />
+    <meta property="og:site_name" content="noteblock-studio-next.vercel.app" />
+    <meta property="og:locale" content="en_US" />
+
+    <!-- Twitter Card meta tags -->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Noteblock Studio Next" />
+    <meta
+        name="twitter:description"
+        content="A modern, web-based music editor for Minecraft Note Block musics."
+    />
+    <meta name="twitter:url" content="https://noteblock-studio-next.vercel.app" />
+    <meta name="twitter:site" content="@noteblock-studio-next" />
+</svelte:head>
+
 {@render children?.()}


### PR DESCRIPTION
Add a <svelte:head> block to the root layout to set the page title,
favicon, and descriptive metadata. Include a site description meta tag
and OpenGraph properties (type, title, description, site_name, locale)
to improve link previews on social platforms. Add Twitter Card meta
tags (card type, title, description, url, site) to optimize sharing on
Twitter.

These changes ensure consistent site identity, improve SEO, and make
shared links display rich previews across social networks.