### PR TITLE
feat/sections-editing

### DIFF
--- a/src/lib/components/editor/editor.svelte
+++ b/src/lib/components/editor/editor.svelte
@@ -167,6 +167,13 @@
                                         editorMouse.handleTimelineBlankPointerDown(contentEl, e);
                                     }
                                 }}
+                                onpointermove={(e) => {
+                                    const contentEl = timelineContentEl as HTMLElement;
+                                    if (!contentEl) return;
+                                    editorMouse.handleTimelineBlankPointerMove(contentEl, e);
+                                }}
+                                onpointerleave={() => editorMouse.handleTimelineBlankPointerLeave()}
+                                onpointercancel={() => editorMouse.handleTimelineBlankPointerLeave()}
                             ></div>
 
                             <!-- Channel row separators -->

--- a/src/lib/components/editor/editor.svelte
+++ b/src/lib/components/editor/editor.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
     import * as Resizable from '$lib/components/ui/resizable';
+    import { commandManager } from '$lib/command-manager';
     import { editorMouse } from '$lib/editor-mouse.svelte';
     import { editorState, PointerMode } from '$lib/editor-state.svelte';
     import { player } from '$lib/playback.svelte';
+    import { onMount } from 'svelte';
     import CommandPalette from './command-palette.svelte';
     import EditorHeader from './editor-header.svelte';
     import MouseWindowEvents from './mouse-window-events.svelte';
@@ -93,6 +95,66 @@
         return 'cursor-default';
     }
     const cursorClass = $derived(computeCursorClass());
+
+    onMount(() => {
+        commandManager.registerCommands([
+            {
+                id: 'delete-selected-sections',
+                title: 'Delete Selected Sections',
+                callback: () => {
+                    if (editorState.selectedSections.length === 0) return;
+
+                    const selectionsToDelete = [...editorState.selectedSections];
+                    selectionsToDelete
+                        .sort(
+                            (a, b) =>
+                                b.channelIndex - a.channelIndex || b.sectionIndex - a.sectionIndex
+                        )
+                        .forEach(({ channelIndex, sectionIndex }) => {
+                            const channel = player.song?.channels[channelIndex];
+                            if (channel && channel.kind === 'note') {
+                                channel.sections.splice(sectionIndex, 1);
+                            }
+                        });
+
+                    player.refreshIndexes();
+                    editorState.clearSelectedSections();
+                },
+                shortcut: 'DELETE'
+            },
+            {
+                id: 'delete-selected-sections-backspace',
+                title: 'Delete Selected Sections (Backspace)',
+                callback: () => {
+                    if (editorState.selectedSections.length === 0) return;
+
+                    const selectionsToDelete = [...editorState.selectedSections];
+                    selectionsToDelete
+                        .sort(
+                            (a, b) =>
+                                b.channelIndex - a.channelIndex || b.sectionIndex - a.sectionIndex
+                        )
+                        .forEach(({ channelIndex, sectionIndex }) => {
+                            const channel = player.song?.channels[channelIndex];
+                            if (channel && channel.kind === 'note') {
+                                channel.sections.splice(sectionIndex, 1);
+                            }
+                        });
+
+                    player.refreshIndexes();
+                    editorState.clearSelectedSections();
+                },
+                shortcut: 'BACKSPACE'
+            }
+        ]);
+
+        return () => {
+            commandManager.unregisterCommands([
+                'delete-selected-sections',
+                'delete-selected-sections-backspace'
+            ]);
+        };
+    });
 </script>
 
 <div class="flex h-screen flex-col">
@@ -173,7 +235,8 @@
                                     editorMouse.handleTimelineBlankPointerMove(contentEl, e);
                                 }}
                                 onpointerleave={() => editorMouse.handleTimelineBlankPointerLeave()}
-                                onpointercancel={() => editorMouse.handleTimelineBlankPointerLeave()}
+                                onpointercancel={() =>
+                                    editorMouse.handleTimelineBlankPointerLeave()}
                             ></div>
 
                             <!-- Channel row separators -->

--- a/src/lib/components/editor/editor.svelte
+++ b/src/lib/components/editor/editor.svelte
@@ -96,54 +96,35 @@
     }
     const cursorClass = $derived(computeCursorClass());
 
+    function deleteSelectedSections() {
+        if (editorState.selectedSections.length === 0) return;
+
+        const selectionsToDelete = [...editorState.selectedSections];
+        selectionsToDelete
+            .sort((a, b) => b.channelIndex - a.channelIndex || b.sectionIndex - a.sectionIndex)
+            .forEach(({ channelIndex, sectionIndex }) => {
+                const channel = player.song?.channels[channelIndex];
+                if (channel && channel.kind === 'note') {
+                    channel.sections.splice(sectionIndex, 1);
+                }
+            });
+
+        player.refreshIndexes();
+        editorState.clearSelectedSections();
+    }
+
     onMount(() => {
         commandManager.registerCommands([
             {
                 id: 'delete-selected-sections',
                 title: 'Delete Selected Sections',
-                callback: () => {
-                    if (editorState.selectedSections.length === 0) return;
-
-                    const selectionsToDelete = [...editorState.selectedSections];
-                    selectionsToDelete
-                        .sort(
-                            (a, b) =>
-                                b.channelIndex - a.channelIndex || b.sectionIndex - a.sectionIndex
-                        )
-                        .forEach(({ channelIndex, sectionIndex }) => {
-                            const channel = player.song?.channels[channelIndex];
-                            if (channel && channel.kind === 'note') {
-                                channel.sections.splice(sectionIndex, 1);
-                            }
-                        });
-
-                    player.refreshIndexes();
-                    editorState.clearSelectedSections();
-                },
+                callback: deleteSelectedSections,
                 shortcut: 'DELETE'
             },
             {
                 id: 'delete-selected-sections-backspace',
                 title: 'Delete Selected Sections (Backspace)',
-                callback: () => {
-                    if (editorState.selectedSections.length === 0) return;
-
-                    const selectionsToDelete = [...editorState.selectedSections];
-                    selectionsToDelete
-                        .sort(
-                            (a, b) =>
-                                b.channelIndex - a.channelIndex || b.sectionIndex - a.sectionIndex
-                        )
-                        .forEach(({ channelIndex, sectionIndex }) => {
-                            const channel = player.song?.channels[channelIndex];
-                            if (channel && channel.kind === 'note') {
-                                channel.sections.splice(sectionIndex, 1);
-                            }
-                        });
-
-                    player.refreshIndexes();
-                    editorState.clearSelectedSections();
-                },
+                callback: deleteSelectedSections,
                 shortcut: 'BACKSPACE'
             }
         ]);

--- a/src/lib/components/editor/note-channel/note-channel.svelte
+++ b/src/lib/components/editor/note-channel/note-channel.svelte
@@ -1,5 +1,8 @@
 <script lang="ts">
+    import { editorMouse } from '$lib/editor-mouse.svelte';
+    import { editorState } from '$lib/editor-state.svelte';
     import type { NoteChannel } from '$lib/types';
+    import Plus from '~icons/lucide/plus';
     import NoteSection from './note-section.svelte';
 
     interface Props {
@@ -9,7 +12,24 @@
     }
 
     let { channel, index, rowHeight = 72 }: Props = $props();
+
+    const hover = $derived(editorMouse.newSectionHover);
+    const pxPerTick = $derived(
+        editorState.ticksPerBeat > 0 ? editorState.pxPerBeat / editorState.ticksPerBeat : 0
+    );
 </script>
+
+{#if hover && hover.channelIndex === index}
+    {@const left = hover.startingTick * pxPerTick}
+    {@const width = Math.max(1, hover.length * pxPerTick)}
+    {@const top = index * rowHeight}
+    <div
+        class="absolute new-section-preview"
+        style={`left:${left}px; top:${top}px; width:${width}px; height:${rowHeight}px;`}
+    >
+        <Plus width={24} height={24} class="pointer-events-none" />
+    </div>
+{/if}
 
 <!-- Renders all sections belonging to a single note channel on its row -->
 {#each channel.sections as section, sIdx}
@@ -21,3 +41,20 @@
         {rowHeight}
     />
 {/each}
+
+<style>
+    .new-section-preview {
+        pointer-events: none;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        border-radius: 0.5rem;
+        border: 2px dashed rgba(16, 185, 129, 0.75);
+        background: rgba(16, 185, 129, 0.18);
+        color: rgba(16, 185, 129, 0.9);
+        font-weight: 600;
+        z-index: 5;
+        transition: opacity 120ms ease;
+    }
+
+</style>

--- a/src/lib/components/editor/note-channel/note-channel.svelte
+++ b/src/lib/components/editor/note-channel/note-channel.svelte
@@ -24,7 +24,7 @@
     {@const width = Math.max(1, hover.length * pxPerTick)}
     {@const top = index * rowHeight}
     <div
-        class="absolute new-section-preview"
+        class="new-section-preview absolute"
         style={`left:${left}px; top:${top}px; width:${width}px; height:${rowHeight}px;`}
     >
         <Plus width={24} height={24} class="pointer-events-none" />
@@ -56,5 +56,4 @@
         z-index: 5;
         transition: opacity 120ms ease;
     }
-
 </style>

--- a/src/lib/components/editor/note-channel/note-section.svelte
+++ b/src/lib/components/editor/note-channel/note-section.svelte
@@ -178,6 +178,7 @@
     onpointerdown={onPointerDown}
     onpointermove={(ev) =>
         editorMouse.handleSectionPointerMove(channelIndex, sectionIndex, section, null, ev)}
+    onpointerenter={() => editorMouse.clearNewSectionHover()}
     onpointerleave={() => editorMouse.handleSectionPointerLeave(channelIndex, sectionIndex)}
     ondblclick={handleOpenPianoRoll}
     role="button"

--- a/src/lib/editor-mouse.svelte.ts
+++ b/src/lib/editor-mouse.svelte.ts
@@ -18,9 +18,9 @@ export class EditorMouseController {
     // Merge-mode hover state: { channelIndex, sectionIndex } when hovering a section (to merge with its next)
     mergeHover = $state<{ channelIndex: number; sectionIndex: number } | null>(null);
     // Blank-area hover state for creating a new section
-    newSectionHover = $state<
-        { channelIndex: number; startingTick: number; length: number } | null
-    >(null);
+    newSectionHover = $state<{ channelIndex: number; startingTick: number; length: number } | null>(
+        null
+    );
 
     // Context captured on pointerdown
     private _contentEl: HTMLElement | null = null;

--- a/src/lib/playback.svelte.ts
+++ b/src/lib/playback.svelte.ts
@@ -367,11 +367,19 @@ export class Player {
     }
 
     /**
-     * Snap a tick to the start of its bar.
+     * Snap a tick to the start of the nearest bar.
      */
-    snapTickToBarStart(tick: number): number {
-        const bar = this.getBarAtTick(tick);
-        return this.findTickForBarBeat(bar, 0).tick;
+    snapTickToNearestBarStart(tick: number): number {
+        const { bar } = this.computeBarBeatAtTick(tick);
+        const currentBarStart = this.findTickForBarBeat(bar, 0).tick;
+        const nextBarStart = this.findTickForBarBeat(bar + 1, 0).tick;
+
+        // Calculate distance to current bar start and next bar start
+        const distanceToCurrent = Math.abs(tick - currentBarStart);
+        const distanceToNext = Math.abs(tick - nextBarStart);
+
+        // Return the closer bar start
+        return distanceToCurrent <= distanceToNext ? currentBarStart : nextBarStart;
     }
 
     /**
@@ -689,7 +697,7 @@ export class Player {
         for (const channel of song.channels) {
             if (channel.kind === 'tempo') {
                 for (const tempoChange of channel.tempoChanges) {
-                    tempoChange.tick = this.snapTickToBarStart(tempoChange.tick);
+                    tempoChange.tick = this.snapTickToNearestBarStart(tempoChange.tick);
                 }
             }
         }
@@ -827,7 +835,7 @@ export class Player {
 
         // Ensure tempo changes are at bar boundaries
         for (const tempoChange of channel.tempoChanges) {
-            tempoChange.tick = this.snapTickToBarStart(tempoChange.tick);
+            tempoChange.tick = this.snapTickToNearestBarStart(tempoChange.tick);
         }
 
         // Refresh indexes to ensure player state is synchronized


### PR DESCRIPTION
### Summary

- Click empty note channels to create a new section (newSection + pointer start channel tracking).
- Add DELETE and BACKSPACE shortcuts to remove selected note sections; centralized deleteSelectedSections handler.
- Support shift-key multi-select and toggle behavior for click, drag, resize, and marquee selection.
- Snap edits (shears hover, split, resize, drag, tempo operations) to the nearest bar start.

### What changed

- Pointer handling: newSectionHover, start channel index tracking, and clearing hover on pointer lifecycle events; click-to-create on empty note channels.
- Selection & dragging: startShiftKey tracking, shift+click toggle/add behavior, preserve/add-to selection with shift, and prevent unintended drags when deselecting.
- Deletion: register/unregister delete-selected-sections and delete-selected-sections-backspace commands; unified deleteSelectedSections function that sorts deletions, refreshes player indexes, and clears selection.
- Snapping: replaced snapTickToBarStart with snapTickToNearestBarStart across shears hover, split, resize, drag, and playback/tempo logic.
- Minor tidies: formatting, ordering, CSS class order, and type reformatting for readability.

### Notes

- DELETE/BACKSPACE now remove selected sections.
- Section creation, multi-selection, deletion, and snapping behave more consistently and musically.