### PR TITLE
fix(piano-roll): normalize Backspace shortcut to uppercase

### DIFF
--- a/src/lib/components/editor/note-channel/note-piano-roll.svelte
+++ b/src/lib/components/editor/note-channel/note-piano-roll.svelte
@@ -100,7 +100,7 @@
             {
                 id: 'piano-roll-backspace-selected-notes',
                 title: 'Delete Selected Notes',
-                shortcut: 'Backspace',
+                shortcut: 'BACKSPACE',
                 callback: () => pianoRollMouse.deleteSelectedNotes()
             }
         ]);


### PR DESCRIPTION
Update the piano roll's "Delete Selected Notes" shortcut value from
'Backspace' to 'BACKSPACE' to match the application's convention for
keyboard shortcut identifiers. This ensures consistency with other
shortcut definitions and prevents potential mismatches when comparing
or registering shortcuts in a case-sensitive lookup.