### PR TITLE
feat(export): add NBS via File System API and fallback

### DIFF
--- a/src/lib/components/editor/editor-title-dropdown.svelte
+++ b/src/lib/components/editor/editor-title-dropdown.svelte
@@ -7,6 +7,7 @@
         DropdownMenuTrigger
     } from '$lib/components/ui/dropdown-menu';
     import { downloadSongAsNbx, songToNbx } from '$lib/files';
+    import { downloadSongAsNbs, songToNbs } from '$lib/nbs';
     import { player } from '$lib/playback.svelte';
     import { onMount } from 'svelte';
     import { toast } from 'svelte-sonner';
@@ -71,6 +72,60 @@
         downloadSongAsNbx(player.song, suggestedName);
     }
 
+    async function handleExportAsNbs() {
+        if (!player.song) {
+            console.warn('No song loaded to export');
+            return;
+        }
+
+        const suggestedName = player.song.name || 'Untitled';
+        await exportSongWithPicker(suggestedName);
+    }
+
+    async function exportSongWithPicker(suggestedName: string) {
+        if (!player.song) return;
+
+        // Try modern File System Access API first
+        if ('showSaveFilePicker' in window) {
+            try {
+                const options = {
+                    suggestedName: `${suggestedName}.nbs`,
+                    types: [
+                        {
+                            description: 'Note Block Studio Song',
+                            accept: {
+                                'application/octet-stream': ['.nbs']
+                            }
+                        }
+                    ]
+                };
+
+                const handle = await (window as any).showSaveFilePicker(options);
+                const nbsData = songToNbs(player.song);
+
+                // Create a new non-resizable ArrayBuffer and copy the data
+                const buffer = new ArrayBuffer(nbsData.byteLength);
+                const view = new Uint8Array(buffer);
+                view.set(new Uint8Array(nbsData));
+
+                const writable = await handle.createWritable();
+                await writable.write(buffer);
+                await writable.close();
+
+                toast.success('Song exported as NBS file!');
+                return;
+            } catch (error: any) {
+                if (error.name === 'AbortError') {
+                    return;
+                }
+            }
+        }
+
+        // Fallback to regular download
+        downloadSongAsNbs(player.song, suggestedName);
+        toast.success('Song exported as NBS file!');
+    }
+
     onMount(() => {
         commandManager.registerCommands([
             {
@@ -84,10 +139,16 @@
                 title: 'Save As',
                 callback: handleSaveAs,
                 shortcut: 'MOD+SHIFT+S'
+            },
+            {
+                id: 'export-nbs',
+                title: 'Export as NBS',
+                callback: handleExportAsNbs,
+                shortcut: 'MOD+SHIFT+N'
             }
         ]);
 
-        return () => commandManager.unregisterCommands(['save', 'save-as']);
+        return () => commandManager.unregisterCommands(['save', 'save-as', 'export-nbs']);
     });
 </script>
 
@@ -99,5 +160,6 @@
         <!-- TODO: Enable Save button on desktop environments where we can save to a known location -->
         <DropdownMenuItem onclick={handleSave} disabled>Save</DropdownMenuItem>
         <DropdownMenuItem onclick={handleSaveAs}>Save As</DropdownMenuItem>
+        <DropdownMenuItem onclick={handleExportAsNbs}>Export as NBS</DropdownMenuItem>
     </DropdownMenuContent>
 </DropdownMenu>


### PR DESCRIPTION
Add nbs export support and integrate export action into editor
 and command palette. Introduce newbs utility file that
converts Song objects to NBS format (songTobs) and return an
ArrayBuffer suitable for writing. In the editor title dropdown:
- import songToNbs/downloadSongAsNbs
- add Export as NBS menu item and command (MOD+SHIFT+N)
- register/unregister the new command
- implement handleExportAsNbs which uses exportSongWithPicker

Implement exportSongWithPicker to prefer the modern File System
Access API (showSaveFilePicker). When available, it constructs an
.nbs file, converts the song to an ArrayBuffer, writes it via the
writable stream, and shows success toast. If the picker is not
available or the user aborts, fall back to the existing download
helper and still show a success toast.

Also add utility helpers and notes-to-NBS mapping scaffolding in
src/lib/nbs.ts and a clampNumber fix. These changes enable direct
desktop-like saving of NBS files while preserving a browser
download fallback.