### PR TITLE
chore(config): add Cloudflare Wrangler configuration

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,26 @@
+name = "noteblock-studio-next"
+compatibility_date = "2024-09-23"
+
+# Enable Node APIs used by some tooling/libraries
+compatibility_flags = ["nodejs_compat"]
+
+# Build the project before deploying
+[build]
+command = "pnpm build"
+
+# Workers (SSR) deployment:
+# If the build produces a Cloudflare worker bundle, deploy it.
+# This path is what SvelteKit outputs when targeting Cloudflare.
+main = ".svelte-kit/cloudflare/_worker.js"
+
+# Serve static assets from the project's static directory when using Workers
+# (SvelteKit will also handle assets under /_app from the worker bundle)
+[assets]
+directory = "static"
+
+# Cloudflare Pages deployment:
+# If you choose to deploy via Pages, Wrangler will use this output dir after running the build command.
+[pages]
+build_output_dir = ".svelte-kit/cloudflare"
+build_command = "pnpm build"
+


### PR DESCRIPTION
- Add wrangler.toml to configure Cloudflare deployment for the SvelteKit project
- Set project name and compatibility_date; enable nodejs_compat for Node API support
- Declare build commands for Workers and Pages
- Configure Workers: main -> .svelte-kit/cloudflare/_worker.js, serve static assets from static directory
- Configure Pages: build output -> .svelte-kit/cloudflare, build_command -> pnpm build