### PR TITLE
chore(meta): update twitter url to custom domain

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -34,7 +34,7 @@
         name="twitter:description"
         content="A modern, web-based music editor for Minecraft Note Block musics."
     />
-    <meta name="twitter:url" content="https://noteblock-studio-next.vercel.app" />
+    <meta name="twitter:url" content="https://ns.nath.tw" />
     <meta name="twitter:site" content="@noteblock-studio-next" />
 </svelte:head>
 


### PR DESCRIPTION
Change the Twitter card URL meta tag from the Vercel deployment
noteblock-studio-next.vercel.app to the project's custom domain ns.nath.tw.
This ensures social previews and shared links reference the canonical site
instead of the temporary hosting domain.