### PR TITLE
feat(playback): ensure trailing bars after section changes

### DIFF
--- a/src/lib/editor-mouse.svelte.ts
+++ b/src/lib/editor-mouse.svelte.ts
@@ -728,6 +728,12 @@ export class EditorMouseController {
                 }
             }
 
+            // Ensure song length accommodates moved sections
+            for (const m of moves) {
+                const endTick = m.newStart + (m.item.section.length ?? 0);
+                player.ensureTrailingBarsAfterTick(endTick, 16);
+            }
+
             // Notify player indexes updated (live)
             player.refreshIndexes();
             this._moved = true;


### PR DESCRIPTION
Add logic to extend the song length so there are at least 16 bars
after any section's end when sections are added, moved, or updated.
Introduce ensureTrailingBarsAfterTick(referenceTick, minBars) which
computes local ticks-per-bar from the segment at the reference tick and
increases song.length when needed.

Call this helper after:
- editing section properties (refresh path)
- applying history-backed section updates
- inserting a new section (with and without history)
- moving sections via the editor mouse handler

This prevents sections from being placed or resized beyond the song
end without creating trailing bars, avoiding truncated playback and
indexing issues.