### PR TITLE
fix(editor): save shortcut to MOD+S and remove duplicate

### DIFF
--- a/src/lib/components/editor/editor-title-dropdown.svelte
+++ b/src/lib/components/editor/editor-title-dropdown.svelte
@@ -129,16 +129,10 @@
     onMount(() => {
         commandManager.registerCommands([
             {
-                id: 'save',
-                title: 'Save',
-                callback: handleSave,
-                shortcut: 'MOD+S'
-            },
-            {
                 id: 'save-as',
                 title: 'Save As',
                 callback: handleSaveAs,
-                shortcut: 'MOD+SHIFT+S'
+                shortcut: 'MOD+S'
             },
             {
                 id: 'export-nbs',


### PR DESCRIPTION
Change the registered commands in the editor title dropdown to use
a single save shortcut. The "save" command entry was removed and the
"save-as" command now uses MOD+S instead of MOD+SHIFT+S.

This prevents duplicate or conflicting save shortcuts and simplifies
command handling so that save actions consistently use the MOD+S key.