### PR TITLE
feat(piano-roll): add-mode hover preview and clears

### DIFF
--- a/src/lib/components/editor/note-channel/note-piano-roll.svelte
+++ b/src/lib/components/editor/note-channel/note-piano-roll.svelte
@@ -385,6 +385,7 @@
                                     onpointermove={pianoRollMouse.handleGridPointerMove}
                                     onpointerup={pianoRollMouse.handleGridPointerUp}
                                     onpointercancel={pianoRollMouse.handleGridPointerCancel}
+                                    onpointerleave={pianoRollMouse.handleGridPointerLeave}
                                 >
                                     <TimelineGrid
                                         gutterWidth={0}
@@ -430,6 +431,19 @@
                                                 )}
                                         ></div>
                                     {/each}
+
+                                    <!-- Hover note preview for pen mode -->
+                                    {#if pianoRollState.hoverNote && pianoRollState.pointerMode === 'pen'}
+                                        {@const hover = pianoRollState.hoverNote}
+                                        {@const left = Math.max(0, Math.round(hover.tick * pianoRollState.pxPerTick))}
+                                        {@const top = (pianoRollState.keyRange.max - hover.key) * pianoRollState.keyHeight + ((pianoRollState.keyHeight - pianoRollState.noteLaneHeight) / 2)}
+                                        {@const width = Math.max(8, Math.round(1 * pianoRollState.pxPerTick))}
+                                        {@const height = pianoRollState.noteLaneHeight}
+                                        <div
+                                            class="hover-note-preview absolute z-25 rounded-sm border-2 border-dashed pointer-events-none"
+                                            style={`left:${left}px; top:${top}px; width:${width}px; height:${height}px;`}
+                                        ></div>
+                                    {/if}
                                 </div>
                             </div>
                             {#if pianoRollState.pointerMode === PointerMode.Normal}
@@ -506,5 +520,14 @@
             background-color 240ms ease,
             border-color 240ms ease;
         /* Let the transition happen naturally to the element's original styles */
+    }
+
+    /* Hover note preview for pen mode */
+    .hover-note-preview {
+        border-color: rgba(16, 185, 129, 0.8);
+        background: rgba(16, 185, 129, 0.2);
+        color: rgba(16, 185, 129, 0.9);
+        font-weight: 600;
+        transition: opacity 120ms ease;
     }
 </style>

--- a/src/lib/piano-roll-state.svelte.ts
+++ b/src/lib/piano-roll-state.svelte.ts
@@ -40,6 +40,9 @@ export class PianoRollState {
     } | null>(null);
     isMouseActive = $state(false);
 
+    // Hover state for pen mode preview
+    hoverNote = $state<{ tick: number; key: number } | null>(null);
+
     // Overlay optimization
     private overlayPendingRect: {
         left: number;
@@ -259,6 +262,7 @@ export class PianoRollState {
         // Clear selection state when changing modes
         this.selectionBox = null;
         this.selectionOverlayRect = null;
+        this.hoverNote = null;
         this.cancelOverlayFrame();
 
         // In pen mode, clear selected notes


### PR DESCRIPTION
IntroduceNote state to support live pen-mode preview when the
pointer moves over the piano roll grid. Add hoverNote to the shared
piano roll state and wire updates in the pointer handling logic so the
UI can show a dashed, non-interactive preview block at the target tick
and key when no existing note occupies that position.

Clear hoverNote alongside other transient interaction state (selection,
selection overlay, drag context) on pointer end/cancel flows and when
changing pointer modes or leaving the grid to avoid stale previews.

Add handleGridPointerLeave to clear hover state on pointerleave, and
render a hover-note preview element in the piano-roll component only
when pointerMode is 'pen' and hoverNote is set.

This improves UX for pen drawing by giving users immediate visual
feedback about where a new note would be placed.