### PR TITLE
fix(editor): avoid starting channel drag from elements

### DIFF
--- a/src/lib/editor-mouse.svelte.ts
+++ b/src/lib/editor-mouse.svelte.ts
@@ -268,9 +268,20 @@ export class EditorMouseController {
 
     // --- Channel reorder: pointer down on gutter to begin drag ---
     handleChannelPointerDown = (channelIndex: number, ev: PointerEvent) => {
-        console.log('handle channel pointer down');
         if (ev.button !== 0) return;
         if (editorState.pointerMode !== PointerMode.Normal) return;
+
+        // If the pointerdown originated from an interactive element (buttons, inputs, selects, links,
+        // or other elements marked to opt-out), do not start a channel drag. This allows clicks on
+        // controls inside the channel info (solo/mute, instrument selector, etc.) to work normally.
+        const target = ev.target as HTMLElement | null;
+        if (target) {
+            const interactive = target.closest(
+                'button, [role="button"], input, select, textarea, a, label, [data-ignore-drag], .no-drag'
+            );
+            if (interactive) return;
+        }
+
         ev.preventDefault();
         ev.stopPropagation();
 


### PR DESCRIPTION
Prevent channel reordering from starting when the pointerdown originates
inside interactive controls or explicitly opted-out elements (buttons,
inputs, selects, links, labels, [data-ignore-drag], .no-drag). This stops
clicks on channel controls (/mute, instrument selectors, etc.) from
being interpreted as drag starts and preserves their normal behavior.

Add a nearest-ancestor check on the event target before initiating drag,
and bail out if a matching interactive element is found. Also keep the
existing guards for non-left button clicks and non-normal pointer modes.