### PR TITLE
feat(player): add clear-solo action and single-action solo toggle

### DIFF
--- a/src/lib/history/actions/player.ts
+++ b/src/lib/history/actions/player.ts
@@ -108,6 +108,38 @@ export function createSetSoloAction(
 }
 
 /**
+ * Action for clearing solo (unmute all note channels) and restoring previous states on undo
+ */
+export function createClearSoloAction(previousMuteStates: boolean[]): HistoryAction {
+    return {
+        label: 'Clear solo',
+        do(ctx) {
+            const song = getSong(ctx.player);
+            for (const channel of song.channels) {
+                if (channel?.kind === 'note') {
+                    channel.isMuted = false;
+                }
+            }
+            ctx.player.refreshIndexes();
+        },
+        undo(ctx) {
+            const song = getSong(ctx.player);
+            let noteIdx = 0;
+            for (let i = 0; i < song.channels.length; i++) {
+                const channel = song.channels[i];
+                if (channel?.kind === 'note') {
+                    if (noteIdx < previousMuteStates.length) {
+                        channel.isMuted = previousMuteStates[noteIdx];
+                        noteIdx++;
+                    }
+                }
+            }
+            ctx.player.refreshIndexes();
+        }
+    };
+}
+
+/**
  * Action for updating a note channel with partial data
  */
 export function createUpdateNoteChannelAction(


### PR DESCRIPTION
Add createClearAction and integrate it playback solo handling
so clearing solo (unmuting all note channels) is performed as a single
history action that records prior mute states for undo.

Change solo toggle logic to detect when the selected note channel is
already the only unmuted channel, then execute the clear-solo action and
return. For other cases, capture previous mute states and execute a
single set-solo action that mutes others and unmutes the target.

This ensures solo/clear operations are atomic in history, making undo/redo
behave predictably and restoring prior mute states correctly.

- Add createClearSoloAction to record and restore previous mute states when clearing solo
- Integrate clear-solo action into solo toggle flow to perform clear as a single history action
- Update solo toggle to detect "already soloed" case and run clear-solo
- Capture previous mute states and execute a single set-solo action for non-clear cases
- Make solo/clear operations atomic for correct undo/redo behavior