### PR TITLE
feat(playhead): animate cursor smoothly while playing

### DIFF
--- a/src/lib/components/editor/playhead-cursor.svelte
+++ b/src/lib/components/editor/playhead-cursor.svelte
@@ -31,9 +31,62 @@
     const tickOffset = $derived(tickOffsetProp ?? 0);
     const visible = $derived(visibleProp ?? true);
 
-    const contentX = $derived(Math.max(0, (currentTick - tickOffset) * pxPerTick));
-    const viewportX = $derived(contentX - scrollLeft);
-    const cursorTransitionMs = $derived(Math.max(0, Math.round(1000 / player.tempo)));
+    let animatedViewportX = $state(0);
+    let animationId: number | null = null;
+    let lastAnimationTime = $state(performance.now());
+
+    // Calculate velocity in pixels per millisecond based on tempo
+    const velocityPxPerMs = $derived(() => {
+        if (!player.isPlaying || player.tempo <= 0) return 0;
+        // Convert tempo (ticks per minute) to pixels per millisecond
+        const ticksPerMs = player.tempo / (60 * 1000);
+        return ticksPerMs * pxPerTick;
+    });
+
+    $effect(() => {
+        const animate = (currentTime: number) => {
+            const deltaTime = currentTime - lastAnimationTime;
+            lastAnimationTime = currentTime;
+
+            if (player.isPlaying && velocityPxPerMs() > 0) {
+                // Move at constant velocity based on tempo
+                const targetContentX = Math.max(0, (currentTick - tickOffset) * pxPerTick);
+                const targetViewportX = targetContentX - scrollLeft;
+
+                // Smooth interpolation toward target (handles seeking/jumping)
+                const diff = targetViewportX - animatedViewportX;
+                if (Math.abs(diff) > 2) {
+                    // Large jump - likely a seek, snap closer
+                    animatedViewportX += diff * 0.3;
+                } else {
+                    // Small difference - use tempo-based movement
+                    animatedViewportX += velocityPxPerMs() * deltaTime;
+                }
+            } else {
+                // Not playing - snap to exact position
+                const targetContentX = Math.max(0, (currentTick - tickOffset) * pxPerTick);
+                animatedViewportX = targetContentX - scrollLeft;
+            }
+
+            animationId = requestAnimationFrame(animate);
+        };
+
+        // Start animation loop
+        if (animationId !== null) {
+            cancelAnimationFrame(animationId);
+        }
+
+        lastAnimationTime = performance.now();
+        animationId = requestAnimationFrame(animate);
+
+        // Cleanup on effect destruction
+        return () => {
+            if (animationId !== null) {
+                cancelAnimationFrame(animationId);
+                animationId = null;
+            }
+        };
+    });
 </script>
 
 <!-- Absolute overlay that spans the parent relative container -->
@@ -44,7 +97,7 @@
     {#if visible}
         <div
             class="absolute top-0 bottom-0"
-            style={`transform:translateX(${viewportX}px); transition: transform ${cursorTransitionMs}ms linear;`}
+            style={`transform:translateX(${animatedViewportX}px);`}
         >
             <div class="h-full w-[2px] bg-primary shadow-[0_0_0_1px_hsl(var(--background))]"></div>
         </div>


### PR DESCRIPTION
Replace derived instantaneous cursor position with a frame-driven
animation loop that advances the playhead cursor according to the
player tempo when playback is active. Add state for animatedViewportX,
animationId, and lastAnimationTime, and compute velocity in pixels per
millisecond from tempo and pxPerTick. The effect uses requestAnimationFrame
to incrementally move the cursor, interpolates on large jumps (seeks)
and snaps to exact position when not playing. Remove the CSS transition
and switch the element to use animatedViewportX.

This prevents stuttering when playback is running and allows smooth,
tempo-accurate cursor motion while preserving immediate snaps on pauses
or seeks.