### PR TITLE
refactor(editor): remove redundant background pointer handler

### DIFF
--- a/src/lib/components/editor/editor.svelte
+++ b/src/lib/components/editor/editor.svelte
@@ -446,13 +446,6 @@
                         bind:this={channelScroller}
                         class="flex-1 overflow-auto bg-background"
                         onscroll={onChannelsScroll}
-                        onpointerdown={(e) => {
-                            // Forward background clicks to the same blank-timeline handler
-                            if (e.button !== 0) return;
-                            if (e.target !== e.currentTarget) return;
-                            const contentEl = timelineContentEl;
-                            if (contentEl) editorMouse.handleTimelineBlankPointerDown(contentEl, e);
-                        }}
                     >
                         <div
                             bind:this={timelineContentEl}


### PR DESCRIPTION
Remove an inline onpointerdown handler from the channel scroller that
duplicated the timeline blank-click forwarding logic. The handler checked
for left-button clicks and target equality before calling
editorMouse.handleTimelineBlankPointerDown(contentEl, e). That behavior
is already handled elsewhere, so removing the code reduces duplication
and simplifies the component DOM event surface.

No functional changes intended; this cleans up obsolete event wiring
and lowers the chance of handling the same interaction twice.