### PR TITLE
fix(piano-roll): correct black/white key background classes

### DIFF
--- a/src/lib/components/editor/note-channel/note-piano-roll.svelte
+++ b/src/lib/components/editor/note-channel/note-piano-roll.svelte
@@ -406,7 +406,7 @@
                                 >
                                     {#each pianoRollState.keyRows as row, index}
                                         <div
-                                            class={`flex items-center justify-end pr-3 text-xs ${row.isBlack ? 'bg-muted/70 text-muted-foreground' : 'bg-background'} ${!row.isMinecraftRange ? 'opacity-40' : ''} ${index === pianoRollState.keyRows.length - 1 ? '' : 'border-b border-border/30'} ${row.isOctaveBoundary ? 'border-b-2 border-b-primary/20' : ''}`}
+                                            class={`flex items-center justify-end pr-3 text-xs ${row.isBlack ? 'bg-background' : 'bg-muted/70 text-muted-foreground'} ${!row.isMinecraftRange ? 'opacity-40' : ''} ${index === pianoRollState.keyRows.length - 1 ? '' : 'border-b border-border/30'} ${row.isOctaveBoundary ? 'border-b-2 border-b-primary/20' : ''}`}
                                             style={`height:${pianoRollState.keyHeight}px;`}
                                         >
                                             {row.label}
@@ -455,7 +455,7 @@
 
                                     {#each pianoRollState.keyRows as row, index}
                                         <div
-                                            class={`${row.isBlack ? 'bg-muted/60' : 'bg-background'} ${!row.isMinecraftRange ? 'opacity-40' : ''} absolute right-0 left-0 ${index === pianoRollState.keyRows.length - 1 ? '' : 'border-b border-border/30'} ${row.isOctaveBoundary ? 'border-b-2 border-b-primary/20' : ''}`}
+                                            class={`${row.isBlack ? 'bg-background' : 'bg-muted/60'} ${!row.isMinecraftRange ? 'opacity-40' : ''} absolute right-0 left-0 ${index === pianoRollState.keyRows.length - 1 ? '' : 'border-b border-border/30'} ${row.isOctaveBoundary ? 'border-b-2 border-b-primary/20' : ''}`}
                                             style={`top:${index * pianoRollState.keyHeight}px; height:${pianoRollState.keyHeight}px;`}
                                         ></div>
                                     {/each}


### PR DESCRIPTION
Swap the conditional class order for black and white piano keys in the
piano roll's key row rendering and the key row overlay. Black keys
previously used the muted/background classes intended for white keys,
and vice versa, causing incorrect visual styling.

This change ensures black keys now receive the background class and
white keys receive the muted/foreground treatment, restoring the
intended contrast and improving piano roll readability.