### PR TITLE
feat: better zooming

### DIFF
--- a/src/lib/components/editor/editor.svelte
+++ b/src/lib/components/editor/editor.svelte
@@ -533,6 +533,16 @@
                                 onpointerleave={() => editorMouse.handleTimelineBlankPointerLeave()}
                                 onpointercancel={() =>
                                     editorMouse.handleTimelineBlankPointerLeave()}
+                                onwheel={(e) => {
+                                    if (e.ctrlKey || e.metaKey) {
+                                        e.preventDefault();
+                                        if (e.deltaY < 0) {
+                                            editorState.zoomIn();
+                                        } else if (e.deltaY > 0) {
+                                            editorState.zoomOut();
+                                        }
+                                    }
+                                }}
                             ></div>
 
                             <!-- Channel row separators -->

--- a/src/lib/components/editor/editor.svelte
+++ b/src/lib/components/editor/editor.svelte
@@ -110,8 +110,9 @@
     });
 
     $effect(() => {
-        // Only trigger auto-scroll calculations when actually playing and auto-scroll enabled
-        if (!player.isPlaying || !editorState.autoScrollEnabled) return;
+        // Auto-scroll when playing and auto-scroll enabled, OR when zoom triggers follow cursor
+        const shouldAutoScroll = (player.isPlaying && editorState.autoScrollEnabled) || editorState._shouldFollowAfterZoom;
+        if (!shouldAutoScroll) return;
 
         const scroller = channelScroller;
         if (!scroller) return;
@@ -125,7 +126,7 @@
         const x = playheadContentX;
 
         const isOutOfView = x < left + 4 || x > right - 4; // small margin
-        if (!isOutOfView) return;
+        if (!isOutOfView && !editorState._shouldFollowAfterZoom) return;
 
         // Place playhead near the left edge (with padding), clamped to content bounds
         const desired = Math.round(x - leftPadding);
@@ -133,6 +134,11 @@
         const clamped = Math.min(maxScroll, Math.max(0, desired));
         if (Math.abs(clamped - left) > 1) {
             editorState.setScrollLeft(clamped);
+        }
+
+        // Clear the zoom follow flag after applying
+        if (editorState._shouldFollowAfterZoom) {
+            editorState._shouldFollowAfterZoom = false;
         }
     });
 

--- a/src/lib/components/editor/ruler-shell.svelte
+++ b/src/lib/components/editor/ruler-shell.svelte
@@ -34,8 +34,12 @@
     let scroller: HTMLDivElement | null = null;
     let contentEl: HTMLDivElement | null = null;
 
+    // Throttle scroll events to prevent excessive updates during resize
+    let scrollThrottled = false;
+
     // Keep the internal scroller aligned with the provided scrollLeft prop
-    $effect(() => {
+    // Use $effect.pre to prevent cascading updates during scroll sync
+    $effect.pre(() => {
         const el = scroller;
         if (!el) return;
         if (Math.abs(el.scrollLeft - scrollLeft) > 1) {
@@ -44,10 +48,19 @@
     });
 
     function handleScroll() {
-        const el = scroller;
-        if (!el) return;
-        const left = el.scrollLeft;
-        dispatch('scrollLeftChange', left);
+        if (scrollThrottled) return;
+        scrollThrottled = true;
+
+        requestAnimationFrame(() => {
+            const el = scroller;
+            if (!el) {
+                scrollThrottled = false;
+                return;
+            }
+            const left = el.scrollLeft;
+            dispatch('scrollLeftChange', left);
+            scrollThrottled = false;
+        });
     }
 
     function handlePointerDown(event: PointerEvent) {

--- a/src/lib/editor-state.svelte.ts
+++ b/src/lib/editor-state.svelte.ts
@@ -127,12 +127,44 @@ export class EditorState {
         this.pxPerBeat = Math.round(clamped);
     }
 
+    // Flag to trigger follow cursor logic after zoom
+    _shouldFollowAfterZoom = $state(false);
+
+    // Zoom throttling state
+    private _pendingZoom = $state<number | null>(null);
+    private _zoomThrottleId = $state<number | null>(null);
+
+    private _applyPendingZoom() {
+        if (this._pendingZoom !== null) {
+            this.setPxPerBeat(this._pendingZoom);
+            this._pendingZoom = null;
+            this._shouldFollowAfterZoom = true;
+        }
+        this._zoomThrottleId = null;
+    }
+
+    private _scheduleZoom(newPxPerBeat: number) {
+        this._pendingZoom = newPxPerBeat;
+
+        if (this._zoomThrottleId !== null) {
+            return; // Already scheduled
+        }
+
+        this._zoomThrottleId = requestAnimationFrame(() => {
+            this._applyPendingZoom();
+        });
+    }
+
     zoomIn(factor = 1.2) {
-        this.setPxPerBeat(this.pxPerBeat * factor);
+        const newValue = Math.min(this.maxPxPerBeat, Math.max(this.minPxPerBeat, this.pxPerBeat * factor));
+        const rounded = Math.round(newValue);
+        this._scheduleZoom(rounded);
     }
 
     zoomOut(factor = 1.2) {
-        this.setPxPerBeat(this.pxPerBeat / factor);
+        const newValue = Math.min(this.maxPxPerBeat, Math.max(this.minPxPerBeat, this.pxPerBeat / factor));
+        const rounded = Math.round(newValue);
+        this._scheduleZoom(rounded);
     }
 
     setScrollLeft(px: number) {

--- a/src/lib/editor-state.svelte.ts
+++ b/src/lib/editor-state.svelte.ts
@@ -156,13 +156,19 @@ export class EditorState {
     }
 
     zoomIn(factor = 1.2) {
-        const newValue = Math.min(this.maxPxPerBeat, Math.max(this.minPxPerBeat, this.pxPerBeat * factor));
+        const newValue = Math.min(
+            this.maxPxPerBeat,
+            Math.max(this.minPxPerBeat, this.pxPerBeat * factor)
+        );
         const rounded = Math.round(newValue);
         this._scheduleZoom(rounded);
     }
 
     zoomOut(factor = 1.2) {
-        const newValue = Math.min(this.maxPxPerBeat, Math.max(this.minPxPerBeat, this.pxPerBeat / factor));
+        const newValue = Math.min(
+            this.maxPxPerBeat,
+            Math.max(this.minPxPerBeat, this.pxPerBeat / factor)
+        );
         const rounded = Math.round(newValue);
         this._scheduleZoom(rounded);
     }


### PR DESCRIPTION
Summary
- Throttle scroll/resize handlers with requestAnimationFrame and batch DOM writes to reduce jank and CPU usage.
- Cache viewport width (updated on RAF/resize) and limit auto-scroll checks to active playback + enabled auto-scroll.
- Preserve viewport center when zooming by adjusting scroll after pxPerBeat changes (previous helper implementation).
- Simplify zoom logic: replace scroll-correction helper with follow-after-zoom flag that recenters on the playhead after zoom and clears the flag.
- Add Ctrl/Cmd+wheel support on timeline blank area to perform editor zoom (prevents browser page zoom).

Changes
- Add RAF-based throttling for channel and channel-info scroll handlers; switch reactive effects to pre to avoid cascading writes.
- Batch scrollLeft/scrollTop assignments to reduce layout thrashing.
- Cache viewport width with scheduled RAF updates; add window resize handler to refresh it.
- Implement zoomWithScrollCorrection (later replaced by follow-after-zoom approach) and then simplified zoom: setPxPerBeat + _shouldFollowAfterZoom flag.
- Update auto-scroll effect to honor the follow-after-zoom flag and to only run when appropriate.
- Add wheel event handling for Ctrl/Cmd + wheel on timeline blank area to call zoomIn/zoomOut and prevent default browser zoom.

Motivation
- Improve scrolling/resize performance and robustness.
- Provide a smoother UX when zooming (no sudden jumps) and a familiar Ctrl/Cmd+wheel zoom gesture.