### PR TITLE
feat(editor): add global Ctrl/Cmd+wheel zoom handling

### DIFF
--- a/src/lib/components/editor/editor.svelte
+++ b/src/lib/components/editor/editor.svelte
@@ -481,16 +481,6 @@
                                 onpointerleave={() => editorMouse.handleTimelineBlankPointerLeave()}
                                 onpointercancel={() =>
                                     editorMouse.handleTimelineBlankPointerLeave()}
-                                onwheel={(e) => {
-                                    if (e.ctrlKey || e.metaKey) {
-                                        e.preventDefault();
-                                        if (e.deltaY < 0) {
-                                            editorState.zoomIn();
-                                        } else if (e.deltaY > 0) {
-                                            editorState.zoomOut();
-                                        }
-                                    }
-                                }}
                             ></div>
 
                             <!-- Channel row separators -->

--- a/src/lib/components/editor/mouse-window-events.svelte
+++ b/src/lib/components/editor/mouse-window-events.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import { editorMouse } from '$lib/editor-mouse.svelte';
+    import { editorState } from '$lib/editor-state.svelte';
 </script>
 
 <svelte:window

--- a/src/lib/components/editor/mouse-window-events.svelte
+++ b/src/lib/components/editor/mouse-window-events.svelte
@@ -7,4 +7,14 @@
     onpointerup={editorMouse.handleWindowPointerUp}
     onpointercancel={() => editorMouse.cancel()}
     onpointerleave={() => editorMouse.cancel()}
+    onwheel={(e) => {
+        if (e.ctrlKey || e.metaKey) {
+            e.preventDefault();
+            if (e.deltaY < 0) {
+                editorState.zoomIn();
+            } else if (e.deltaY > 0) {
+                editorState.zoomOut();
+            }
+        }
+    }}
 />


### PR DESCRIPTION
Move Ctrl/Cmd + mouse wheel zoom handling from the timeline area to the
window-level pointer container so zoom gestures work regardless of
cursor position. The handler prevents default scrolling when Ctrl or Cmd
is held and dispatches editorState.zoomIn/zoomOut based on wheel
direction. This centralizes zoom behavior and avoids duplicate handlers
in the timeline element.