### PR TITLE
feat(editor): add wheel-to-zoom handling and delegate events

### DIFF
--- a/src/lib/components/editor/editor.svelte
+++ b/src/lib/components/editor/editor.svelte
@@ -481,6 +481,7 @@
                                 onpointerleave={() => editorMouse.handleTimelineBlankPointerLeave()}
                                 onpointercancel={() =>
                                     editorMouse.handleTimelineBlankPointerLeave()}
+                                onwheel={editorMouse.handleWheel}
                             ></div>
 
                             <!-- Channel row separators -->

--- a/src/lib/components/editor/mouse-window-events.svelte
+++ b/src/lib/components/editor/mouse-window-events.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
     import { editorMouse } from '$lib/editor-mouse.svelte';
-    import { editorState } from '$lib/editor-state.svelte';
 </script>
 
 <svelte:window
@@ -8,14 +7,4 @@
     onpointerup={editorMouse.handleWindowPointerUp}
     onpointercancel={() => editorMouse.cancel()}
     onpointerleave={() => editorMouse.cancel()}
-    onwheel={(e) => {
-        if (e.ctrlKey || e.metaKey) {
-            e.preventDefault();
-            if (e.deltaY < 0) {
-                editorState.zoomIn();
-            } else if (e.deltaY > 0) {
-                editorState.zoomOut();
-            }
-        }
-    }}
 />

--- a/src/lib/components/editor/note-channel/note-piano-roll.svelte
+++ b/src/lib/components/editor/note-channel/note-piano-roll.svelte
@@ -430,6 +430,7 @@
                                     onpointerup={pianoRollMouse.handleGridPointerUp}
                                     onpointercancel={pianoRollMouse.handleGridPointerCancel}
                                     onpointerleave={pianoRollMouse.handleGridPointerLeave}
+                                    onwheel={editorMouse.handleWheel}
                                 >
                                     <TimelineGrid
                                         gutterWidth={0}

--- a/src/lib/components/editor/note-channel/note-piano-roll.svelte
+++ b/src/lib/components/editor/note-channel/note-piano-roll.svelte
@@ -398,7 +398,7 @@
                                     if (!grid) return;
                                     grid.scrollBy({ left: event.deltaX, top: event.deltaY });
 
-                                    event.preventDefault();
+                                    editorMouse.handleWheel(event);
                                     event.preventDefault();
                                 }}
                             >
@@ -433,7 +433,6 @@
                                     onpointerup={pianoRollMouse.handleGridPointerUp}
                                     onpointercancel={pianoRollMouse.handleGridPointerCancel}
                                     onpointerleave={pianoRollMouse.handleGridPointerLeave}
-                                    onwheel={editorMouse.handleWheel}
                                 >
                                     <TimelineGrid
                                         gutterWidth={0}

--- a/src/lib/components/editor/note-channel/note-piano-roll.svelte
+++ b/src/lib/components/editor/note-channel/note-piano-roll.svelte
@@ -397,9 +397,6 @@
                                     const grid = pianoRollState.gridScroller;
                                     if (!grid) return;
                                     grid.scrollBy({ left: event.deltaX, top: event.deltaY });
-
-                                    editorMouse.handleWheel(event);
-                                    event.preventDefault();
                                 }}
                             >
                                 <div

--- a/src/lib/components/editor/note-channel/note-piano-roll.svelte
+++ b/src/lib/components/editor/note-channel/note-piano-roll.svelte
@@ -399,6 +399,7 @@
                                     grid.scrollBy({ left: event.deltaX, top: event.deltaY });
 
                                     event.preventDefault();
+                                    event.preventDefault();
                                 }}
                             >
                                 <div

--- a/src/lib/components/editor/note-channel/note-piano-roll.svelte
+++ b/src/lib/components/editor/note-channel/note-piano-roll.svelte
@@ -397,6 +397,7 @@
                                     const grid = pianoRollState.gridScroller;
                                     if (!grid) return;
                                     grid.scrollBy({ left: event.deltaX, top: event.deltaY });
+
                                     event.preventDefault();
                                 }}
                             >
@@ -431,6 +432,7 @@
                                     onpointerup={pianoRollMouse.handleGridPointerUp}
                                     onpointercancel={pianoRollMouse.handleGridPointerCancel}
                                     onpointerleave={pianoRollMouse.handleGridPointerLeave}
+                                    onwheel={editorMouse.handleWheel}
                                 >
                                     <TimelineGrid
                                         gutterWidth={0}

--- a/src/lib/editor-mouse.svelte.ts
+++ b/src/lib/editor-mouse.svelte.ts
@@ -997,6 +997,17 @@ export class EditorMouseController {
         this.reset();
     };
 
+    handleWheel(ev: WheelEvent) {
+        if (ev.ctrlKey || ev.metaKey) {
+            ev.preventDefault();
+            if (ev.deltaY < 0) {
+                editorState.zoomIn();
+            } else if (ev.deltaY > 0) {
+                editorState.zoomOut();
+            }
+        }
+    }
+
     cancel() {
         this.reset();
     }


### PR DESCRIPTION
Add global wheel-to-zoom support routed through editorMouse so
ctrl/meta + wheel zooms the editor consistently. Move duplicated
zoom logic out of the window listener and into editor-mouse.svelte.ts
(handleWheel), and wire that handler onto relevant editor DOM nodes
(editor blank area and piano roll grid). Remove the unused import of
editorState from mouse-window-events and delete the inline wheel
handler there.

This centralizes zoom behavior, prevents duplicated code, and allows
better control of wheel interactions (preventDefault when zooming).