### PR TITLE
feat: add session flag to suppress resume prompt

### DIFF
--- a/src/lib/components/editor/editor-header.svelte
+++ b/src/lib/components/editor/editor-header.svelte
@@ -11,6 +11,7 @@
     import { editorState, PointerMode } from '$lib/editor-state.svelte';
     import { historyManager } from '$lib/history';
     import { LoopMode, player } from '$lib/playback.svelte';
+    import { flagSuppressNextResumePrompt } from '$lib/song-storage';
     import { cn } from '$lib/utils';
     import Redo from '~icons/lucide/redo';
     import Undo from '~icons/lucide/undo';
@@ -52,6 +53,10 @@
     };
     const toggleMetronome = () => player.setMetronomeEnabled(!player.metronomeEnabled);
     const toggleAutoScroll = () => editorState.setAutoScrollEnabled(!editorState.autoScrollEnabled);
+    const handleBack = () => {
+        flagSuppressNextResumePrompt();
+        history.back();
+    };
 
     let tempoInputElement = $state<HTMLInputElement | null>(null);
 
@@ -239,7 +244,7 @@
             size="icon"
             aria-label="Back"
             class="text-primary"
-            onclick={() => history.back()}
+            onclick={handleBack}
         >
             <ChevronLeft class="size-5" />
         </Button>

--- a/src/lib/song-storage.ts
+++ b/src/lib/song-storage.ts
@@ -2,6 +2,7 @@ import { browser } from '$app/environment';
 import type { Song } from './types';
 
 const STORAGE_KEY = 'noteblock-studio:saved-song';
+const SUPPRESS_PROMPT_KEY = `${STORAGE_KEY}:suppress`;
 
 export interface StoredSongPayload {
     version: number;
@@ -73,6 +74,29 @@ export function hasStoredSong(): boolean {
     try {
         return localStorage.getItem(STORAGE_KEY) !== null;
     } catch {
+        return false;
+    }
+}
+
+export function flagSuppressNextResumePrompt(): void {
+    if (!browser) return;
+    try {
+        sessionStorage.setItem(SUPPRESS_PROMPT_KEY, '1');
+    } catch (error) {
+        console.error('Failed to flag resume prompt suppression', error);
+    }
+}
+
+export function consumeSuppressNextResumePrompt(): boolean {
+    if (!browser) return false;
+    try {
+        const flagged = sessionStorage.getItem(SUPPRESS_PROMPT_KEY) === '1';
+        if (flagged) {
+            sessionStorage.removeItem(SUPPRESS_PROMPT_KEY);
+        }
+        return flagged;
+    } catch (error) {
+        console.error('Failed to read resume prompt suppression flag', error);
         return false;
     }
 }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -8,6 +8,7 @@
     import {
         clearStoredSong,
         loadSongFromStorage,
+        consumeSuppressNextResumePrompt,
         type StoredSongPayload
     } from '$lib/song-storage';
     import type { Song, TempoChannel } from '$lib/types';
@@ -23,6 +24,11 @@
     let storedSong = $state<StoredSongPayload | null>(null);
 
     onMount(() => {
+        if (consumeSuppressNextResumePrompt()) {
+            resumeDialogOpen = false;
+            storedSong = null;
+            return;
+        }
         const stored = loadSongFromStorage();
         if (stored) {
             storedSong = stored;


### PR DESCRIPTION
Introduce a session-scoped flag to suppress the "resume saved song" prompt
when navigating back from the editor. Add helper functions to set and
consume the flag in song-storage, and integrate them into the editor UI.

- Add SUPPRESS_PROMPT_KEY and two APIs:
  - flagSuppressNextResumePrompt(): sets a sessionStorage flag.
  - consumeSuppressNextResumePrompt(): reads and clears the flag.
  Both guard against non-browser environments and log errors on failure.

- Use consumeSuppressNextResumePrompt in +page.svelte on mount to skip
  opening the resume dialog and clear storedSong when the flag is present.

- Add handleBack in editor-header.svelte to set the flag before calling
  history.back(), and wire the Back button to use it.

This prevents the resume dialog from reappearing immediately after the
user navigates back from the editor, improving UX when intentionally
leaving the editor.