### PR TITLE
feat: midi importing

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     },
     "dependencies": {
         "@nbsjs/core": "^6.0.0",
+        "@tonejs/midi": "^2.0.28",
         "jszip": "^3.10.1",
         "mode-watcher": "^1.1.0"
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@nbsjs/core':
         specifier: ^6.0.0
         version: 6.0.0
+      '@tonejs/midi':
+        specifier: ^2.0.28
+        version: 2.0.28
       jszip:
         specifier: ^3.10.1
         version: 3.10.1
@@ -550,6 +553,9 @@ packages:
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7
 
+  '@tonejs/midi@2.0.28':
+    resolution: {integrity: sha512-RII6YpInPsOZ5t3Si/20QKpNqB1lZ2OCFJSOzJxz38YdY/3zqDr3uaml4JuCWkdixuPqP1/TBnXzhQ39csyoVg==}
+
   '@types/cookie@0.6.0':
     resolution: {integrity: sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==}
 
@@ -564,6 +570,9 @@ packages:
   aria-query@5.3.2:
     resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
     engines: {node: '>= 0.4'}
+
+  array-flatten@3.0.0:
+    resolution: {integrity: sha512-zPMVc3ZYlGLNk4mpK1NzP2wg0ml9t7fUgDsayR5Y5rSzxQilzR9FGu/EH2jQOcKSAeAfWeylyW8juy3OkWRvNA==}
 
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
@@ -769,6 +778,9 @@ packages:
 
   magic-string@0.30.19:
     resolution: {integrity: sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw==}
+
+  midi-file@1.2.4:
+    resolution: {integrity: sha512-B5SnBC6i2bwJIXTY9MElIydJwAmnKx+r5eJ1jknTLetzLflEl0GWveuBB6ACrQpecSRkOB6fhTx1PwXk2BVxnA==}
 
   minipass@7.1.2:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
@@ -1497,6 +1509,11 @@ snapshots:
       tailwindcss: 4.1.13
       vite: 7.1.5(jiti@2.5.1)(lightningcss@1.30.1)
 
+  '@tonejs/midi@2.0.28':
+    dependencies:
+      array-flatten: 3.0.0
+      midi-file: 1.2.4
+
   '@types/cookie@0.6.0': {}
 
   '@types/estree@1.0.8': {}
@@ -1504,6 +1521,8 @@ snapshots:
   acorn@8.15.0: {}
 
   aria-query@5.3.2: {}
+
+  array-flatten@3.0.0: {}
 
   axobject-query@4.1.0: {}
 
@@ -1687,6 +1706,8 @@ snapshots:
   magic-string@0.30.19:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  midi-file@1.2.4: {}
 
   minipass@7.1.2: {}
 

--- a/src/lib/components/editor/midi-import-dialog.svelte
+++ b/src/lib/components/editor/midi-import-dialog.svelte
@@ -13,12 +13,12 @@
         TableRow
     } from '$lib/components/ui/table';
     import {
-        createDefaultPercussionMapping,
         guessInstrumentForTrack,
         intoChannelAsInstrument,
         intoChannelWithMapping,
         type PercussionMapping
     } from '$lib/midi';
+    import { PERCUSSION_MAPPING } from '$lib/percussion-mapping';
     import { player } from '$lib/playback.svelte';
     import {
         Instrument,
@@ -151,7 +151,7 @@
                     name: name || `Channel ${channelNumber}`,
                     instrument: defaultInstrument,
                     mode,
-                    percussionMapping: isPercussion ? createDefaultPercussionMapping(track) : null,
+                    percussionMapping: isPercussion ? PERCUSSION_MAPPING : null,
                     transpose: defaultTranspose,
                     transposeWithinRange: false
                 };
@@ -296,7 +296,7 @@
 
         assignment.mode = mode;
         if (mode === 'percussion' && !assignment.percussionMapping) {
-            assignment.percussionMapping = createDefaultPercussionMapping(assignment.track);
+            assignment.percussionMapping = PERCUSSION_MAPPING;
         }
         assignments = [...assignments];
     }

--- a/src/lib/components/editor/midi-import-dialog.svelte
+++ b/src/lib/components/editor/midi-import-dialog.svelte
@@ -1,0 +1,476 @@
+<script lang="ts">
+    import { goto } from '$app/navigation';
+    import InstrumentSelector from '$lib/components/editor/note-channel/instrument-selector.svelte';
+    import Button from '$lib/components/ui/button/button.svelte';
+    import * as Dialog from '$lib/components/ui/dialog/index.js';
+    import {
+        Table,
+        TableBody,
+        TableCell,
+        TableHead,
+        TableHeader,
+        TableRow
+    } from '$lib/components/ui/table';
+    import {
+        createDefaultPercussionMapping,
+        guessInstrumentForTrack,
+        intoChannelAsInstrument,
+        intoChannelWithMapping,
+        type PercussionMapping
+    } from '$lib/midi';
+    import { player } from '$lib/playback.svelte';
+    import {
+        Instrument,
+        INSTRUMENT_ICONS,
+        INSTRUMENT_NAMES,
+        type NoteChannel,
+        type Song,
+        type TempoChannel
+    } from '$lib/types';
+    import type { MidiJSON, TrackJSON } from '@tonejs/midi';
+    import * as MidiModule from '@tonejs/midi';
+    import { toast } from 'svelte-sonner';
+
+    type MidiCtor = typeof import('@tonejs/midi').Midi;
+    const midiCtor =
+        (MidiModule as { Midi?: MidiCtor }).Midi ??
+        (MidiModule as { default?: { Midi?: MidiCtor } }).default?.Midi;
+    if (!midiCtor) {
+        throw new Error('Failed to load @tonejs/midi.');
+    }
+    const Midi = midiCtor;
+
+    type ChannelMode = 'instrument' | 'percussion';
+
+    interface ChannelAssignment {
+        track: TrackJSON;
+        channelNumber: number;
+        name: string;
+        instrument: Instrument;
+        mode: ChannelMode;
+        percussionMapping: PercussionMapping | null;
+    }
+
+    interface Props {
+        open?: boolean;
+    }
+
+    let { open = $bindable(false) }: Props = $props();
+
+    let midiFileName = $state<string | null>(null);
+    let assignments = $state<ChannelAssignment[]>([]);
+    let midiData = $state<MidiJSON | null>(null);
+    let isLoading = $state(false);
+    let errorMessage = $state<string | null>(null);
+
+    let fileInput: HTMLInputElement | null = null;
+
+    const canImport = $derived(
+        assignments.length > 0 && assignments.some((assignment) => assignment.track.notes.length)
+    );
+
+    $effect(() => {
+        if (!open) {
+            resetDialog();
+        }
+    });
+
+    function resetDialog() {
+        midiFileName = null;
+        assignments = [];
+        midiData = null;
+        isLoading = false;
+        errorMessage = null;
+        if (fileInput) {
+            fileInput.value = '';
+        }
+    }
+
+    function openFilePicker() {
+        fileInput?.click();
+    }
+
+    async function handleFileSelection(event: Event) {
+        const input = event.currentTarget as HTMLInputElement;
+        const files = input.files;
+        if (!files || files.length === 0) return;
+
+        const file = files[0];
+        isLoading = true;
+        errorMessage = null;
+
+        try {
+            const buffer = await file.arrayBuffer();
+            const midi = new Midi(buffer);
+            const json = midi.toJSON();
+
+            midiFileName = file.name;
+            midiData = json;
+            assignments = buildAssignments(json);
+
+            if (assignments.length === 0) {
+                errorMessage = 'No playable MIDI tracks were found in this file.';
+            }
+        } catch (error) {
+            console.error('Failed to parse MIDI file', error);
+            errorMessage = 'Failed to read MIDI file. Please make sure it is a valid .mid file.';
+            midiFileName = null;
+            midiData = null;
+            assignments = [];
+        } finally {
+            isLoading = false;
+            if (input) input.value = '';
+        }
+    }
+
+    function buildAssignments(data: MidiJSON): ChannelAssignment[] {
+        return data.tracks
+            .map((track, index) => {
+                const channelNumber = (track.channel ?? index) + 1;
+                const name = (track.name || track.instrument.name || `Track ${index + 1}`).trim();
+                const defaultInstrument = guessInstrumentForTrack(track);
+                const isPercussion = track.channel === 9;
+                const mode: ChannelMode = isPercussion ? 'percussion' : 'instrument';
+
+                return {
+                    track,
+                    channelNumber,
+                    name: name || `Channel ${channelNumber}`,
+                    instrument: defaultInstrument,
+                    mode,
+                    percussionMapping: isPercussion ? createDefaultPercussionMapping(track) : null
+                };
+            })
+            .filter((assignment) => assignment.track.notes.length > 0);
+    }
+
+    function setMode(index: number, mode: ChannelMode) {
+        const assignment = assignments[index];
+        if (!assignment) return;
+
+        assignment.mode = mode;
+        if (mode === 'percussion' && !assignment.percussionMapping) {
+            assignment.percussionMapping = createDefaultPercussionMapping(assignment.track);
+        }
+        assignments = [...assignments];
+    }
+
+    function handleInstrumentChange(index: number, instrument: Instrument) {
+        const assignment = assignments[index];
+        if (!assignment) return;
+
+        assignment.instrument = instrument;
+        assignments = [...assignments];
+    }
+
+    function describeTrack(assignment: ChannelAssignment): string {
+        const noteCount = assignment.track.notes.length;
+        const unique = new Set(assignment.track.notes.map((note) => note.midi)).size;
+        return `${noteCount.toLocaleString()} notes • ${unique.toLocaleString()} unique pitches`;
+    }
+
+    function describePercussion(mapping: PercussionMapping | null): string {
+        if (!mapping) return 'No percussion notes detected.';
+        const entries = Object.values(mapping);
+        if (entries.length === 0) return 'No percussion notes detected.';
+
+        const counts = new Map<Instrument, number>();
+        for (const target of entries) {
+            counts.set(target.instrument, (counts.get(target.instrument) ?? 0) + 1);
+        }
+
+        const summary = Array.from(counts.entries())
+            .sort((a, b) => b[1] - a[1])
+            .map(([instrument, count]) => `${count}x ${INSTRUMENT_NAMES[instrument]}`)
+            .join(', ');
+
+        return `${entries.length} unique MIDI drums -> ${summary}`;
+    }
+
+    async function handleImport() {
+        if (!midiData || assignments.length === 0) return;
+
+        try {
+            const ticksPerBeat = deriveTicksPerBeat();
+            const tickScale = computeTickScale(midiData, ticksPerBeat);
+            const noteChannels: NoteChannel[] = [];
+
+            for (const assignment of assignments) {
+                if (assignment.track.notes.length === 0) continue;
+
+                if (assignment.mode === 'percussion' && assignment.percussionMapping) {
+                    const channels = intoChannelWithMapping(
+                        assignment.track,
+                        assignment.percussionMapping,
+                        tickScale
+                    );
+                    channels.forEach((channel) => {
+                        channel.name = `${assignment.name} (${INSTRUMENT_NAMES[channel.instrument]})`;
+                        noteChannels.push(channel);
+                    });
+                } else {
+                    const channel = intoChannelAsInstrument(
+                        assignment.track,
+                        assignment.instrument,
+                        tickScale
+                    );
+                    channel.name = assignment.name;
+                    noteChannels.push(channel);
+                }
+            }
+
+            if (noteChannels.length === 0) {
+                toast.error('No note data available to import.');
+                return;
+            }
+
+            const tempo = deriveTempo(midiData, ticksPerBeat);
+            const beatsPerBar = deriveBeatsPerBar(midiData);
+
+            const tempoChannel: TempoChannel = {
+                kind: 'tempo',
+                name: 'Tempo',
+                tempoChanges: [
+                    {
+                        tick: 0,
+                        tempo,
+                        ticksPerBeat,
+                        beatsPerBar
+                    }
+                ]
+            };
+
+            const length = calculateSongLength(noteChannels);
+            const songName = midiData.header.name || midiFileName || 'Imported MIDI';
+            const now = new Date().toISOString();
+
+            const song: Song = {
+                length,
+                tempo,
+                channels: [tempoChannel, ...noteChannels],
+                name: songName,
+                author: '',
+                description: '',
+                metadata: {
+                    version: '1.0.0',
+                    format: 'midi-import',
+                    created: now,
+                    modified: now,
+                    assets: []
+                }
+            };
+
+            player.setSong(song);
+            toast.success(`Imported "${song.name}" successfully.`);
+            open = false;
+            await goto('/edit');
+        } catch (error) {
+            console.error('Failed to import MIDI data', error);
+            toast.error('Failed to import MIDI file. Please try again.');
+        }
+    }
+
+    function deriveTicksPerBeat(): number {
+        return 4;
+    }
+
+    function deriveTempo(data: MidiJSON, ticksPerBeat: number): number {
+        const bpm = data.header.tempos?.[0]?.bpm ?? 120;
+        return (ticksPerBeat * bpm) / 60;
+    }
+
+    function computeTickScale(data: MidiJSON, ticksPerBeat: number): number {
+        const ppq = data.header.ppq || 480;
+        if (!Number.isFinite(ppq) || ppq <= 0) return 1;
+        return ticksPerBeat / ppq;
+    }
+
+    function deriveBeatsPerBar(data: MidiJSON): number {
+        const signature = data.header.timeSignatures?.[0]?.timeSignature;
+        const numerator = signature?.[0];
+        if (Number.isFinite(numerator) && numerator > 0) {
+            return Math.min(16, Math.max(1, Math.round(numerator)));
+        }
+        return 4;
+    }
+
+    function calculateSongLength(channels: NoteChannel[]): number {
+        let maxTick = 0;
+        for (const channel of channels) {
+            for (const section of channel.sections) {
+                const sectionStart = section.startingTick;
+                for (const note of section.notes) {
+                    const absoluteTick = sectionStart + note.tick + 1;
+                    if (absoluteTick > maxTick) {
+                        maxTick = absoluteTick;
+                    }
+                }
+            }
+        }
+        return maxTick;
+    }
+</script>
+
+<Dialog.Root bind:open>
+    <Dialog.Content class="flex max-h-[85vh] w-full max-w-5xl flex-col overflow-hidden">
+        <Dialog.Header>
+            <Dialog.Title>Import MIDI</Dialog.Title>
+            <Dialog.Description>
+                Choose a MIDI file, review its tracks, and map each one to a Noteblock instrument
+                before importing.
+            </Dialog.Description>
+        </Dialog.Header>
+
+        <div class="flex-1 space-y-4 overflow-y-auto py-4 pr-1">
+            <input
+                bind:this={fileInput}
+                type="file"
+                accept=".mid,.midi"
+                class="hidden"
+                onchange={handleFileSelection}
+            />
+            <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                <div>
+                    <p class="text-sm font-medium text-muted-foreground">Selected file</p>
+                    {#if midiFileName}
+                        <p class="text-sm font-medium">{midiFileName}</p>
+                    {:else}
+                        <p class="text-sm text-muted-foreground">No file selected</p>
+                    {/if}
+                </div>
+                <Button variant="outline" onclick={openFilePicker} disabled={isLoading}>
+                    {#if isLoading}
+                        Loading...
+                    {:else if midiFileName}
+                        Choose different file
+                    {:else}
+                        Choose MIDI file
+                    {/if}
+                </Button>
+            </div>
+
+            {#if errorMessage}
+                <div
+                    class="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive"
+                >
+                    {errorMessage}
+                </div>
+            {/if}
+
+            {#if assignments.length > 0}
+                <div class="rounded-md border">
+                    <Table class="border-collapse text-sm">
+                        <TableHeader class="bg-muted/40 text-muted-foreground">
+                            <TableRow class="border-border/80">
+                                <TableHead class="w-32 px-4 py-2">MIDI Channel</TableHead>
+                                <TableHead class="w-[30rem] px-4 py-2">Track</TableHead>
+                                <TableHead class="w-[26rem] px-4 py-2">Target</TableHead>
+                            </TableRow>
+                        </TableHeader>
+                        <TableBody>
+                            {#each assignments as assignment, index}
+                                <TableRow class="border-border/60">
+                                    <TableCell
+                                        class="w-24 px-4 py-3 align-top font-mono text-sm font-medium"
+                                    >
+                                        {assignment.channelNumber}
+                                    </TableCell>
+                                    <TableCell class="w-[26rem] px-4 py-3 align-top">
+                                        <p class="font-medium">{assignment.name}</p>
+                                        <p class="text-xs text-muted-foreground">
+                                            {(
+                                                assignment.track.instrument.name ||
+                                                'Unknown instrument'
+                                            ).trim() || 'Unknown instrument'}
+                                            · {describeTrack(assignment)}
+                                        </p>
+                                    </TableCell>
+                                    <TableCell class="w-[22rem] px-4 py-3 align-top">
+                                        <div class="flex flex-col gap-2">
+                                            {#if assignment.track.channel === 9}
+                                                <div class="flex flex-wrap gap-2">
+                                                    <Button
+                                                        size="sm"
+                                                        variant={assignment.mode === 'instrument'
+                                                            ? 'default'
+                                                            : 'outline'}
+                                                        onclick={() => setMode(index, 'instrument')}
+                                                    >
+                                                        Instrument
+                                                    </Button>
+                                                    <Button
+                                                        size="sm"
+                                                        variant={assignment.mode === 'percussion'
+                                                            ? 'default'
+                                                            : 'outline'}
+                                                        onclick={() => setMode(index, 'percussion')}
+                                                    >
+                                                        Percussion
+                                                    </Button>
+                                                </div>
+                                            {/if}
+
+                                            {#if assignment.mode === 'percussion' && assignment.percussionMapping}
+                                                <div
+                                                    class="w-full rounded-md border border-dashed px-3 py-2 text-xs text-muted-foreground"
+                                                >
+                                                    {describePercussion(
+                                                        assignment.percussionMapping
+                                                    )}
+                                                </div>
+                                            {:else}
+                                                <InstrumentSelector
+                                                    selectedInstrument={assignment.instrument}
+                                                    onSelect={(instrument) =>
+                                                        handleInstrumentChange(index, instrument)}
+                                                    triggerClass="h-10 w-full justify-start gap-2"
+                                                    align="start"
+                                                >
+                                                    <img
+                                                        src={INSTRUMENT_ICONS[
+                                                            assignment.instrument
+                                                        ]}
+                                                        alt={INSTRUMENT_NAMES[
+                                                            assignment.instrument
+                                                        ]}
+                                                        class="h-6 w-6 rounded-sm object-contain"
+                                                    />
+                                                    <span class="text-sm"
+                                                        >{INSTRUMENT_NAMES[
+                                                            assignment.instrument
+                                                        ]}</span
+                                                    >
+                                                </InstrumentSelector>
+                                            {/if}
+                                        </div>
+                                    </TableCell>
+                                </TableRow>
+                            {/each}
+                        </TableBody>
+                    </Table>
+                </div>
+            {:else}
+                <div
+                    class="rounded-md border border-dashed px-6 py-12 text-center text-sm text-muted-foreground"
+                >
+                    {#if isLoading}
+                        Reading MIDI file...
+                    {:else}
+                        Select a MIDI file to review its channels before importing.
+                    {/if}
+                </div>
+            {/if}
+        </div>
+
+        <Dialog.Footer>
+            <Button variant="outline" onclick={() => (open = false)}>Cancel</Button>
+            <Button onclick={handleImport} disabled={!canImport}>
+                {#if assignments.length}
+                    Import {assignments.length} Track{assignments.length === 1 ? '' : 's'}
+                {:else}
+                    Import
+                {/if}
+            </Button>
+        </Dialog.Footer>
+    </Dialog.Content>
+</Dialog.Root>

--- a/src/lib/components/editor/midi-import-dialog.svelte
+++ b/src/lib/components/editor/midi-import-dialog.svelte
@@ -11,6 +11,7 @@
         TableHeader,
         TableRow
     } from '$lib/components/ui/table';
+    import { Checkbox } from '$lib/components/ui/checkbox';
     import {
         createDefaultPercussionMapping,
         guessInstrumentForTrack,
@@ -697,15 +698,13 @@
                                                 <label
                                                     class="ml-auto flex cursor-pointer items-center gap-2 text-xs text-muted-foreground select-none"
                                                 >
-                                                    <input
-                                                        type="checkbox"
-                                                        class="h-4 w-4 rounded border border-border bg-background text-primary shadow-sm focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-60"
+                                                    <Checkbox
                                                         checked={transposeWithinRange}
                                                         disabled={!isInstrument}
-                                                        onchange={(event) =>
+                                                        onCheckedChange={(checked) =>
                                                             setTransposeWithinRange(
                                                                 index,
-                                                                event.currentTarget.checked
+                                                                checked ?? false
                                                             )}
                                                     />
                                                     <span class="text-xs text-foreground">

--- a/src/lib/components/editor/midi-import-dialog.svelte
+++ b/src/lib/components/editor/midi-import-dialog.svelte
@@ -603,8 +603,6 @@
                                             assignment.transpose,
                                             assignment.transposeWithinRange
                                         )}
-                                        {@const hasRawOverflow =
-                                            rawStats.above > 0 || rawStats.below > 0}
                                         {@const displayStats = assignment.transposeWithinRange
                                             ? adjustedStats
                                             : rawStats}

--- a/src/lib/components/editor/midi-import-dialog.svelte
+++ b/src/lib/components/editor/midi-import-dialog.svelte
@@ -2,6 +2,7 @@
     import { goto } from '$app/navigation';
     import InstrumentSelector from '$lib/components/editor/note-channel/instrument-selector.svelte';
     import Button from '$lib/components/ui/button/button.svelte';
+    import { Checkbox } from '$lib/components/ui/checkbox';
     import * as Dialog from '$lib/components/ui/dialog/index.js';
     import {
         Table,
@@ -11,7 +12,6 @@
         TableHeader,
         TableRow
     } from '$lib/components/ui/table';
-    import { Checkbox } from '$lib/components/ui/checkbox';
     import {
         createDefaultPercussionMapping,
         guessInstrumentForTrack,
@@ -460,7 +460,7 @@
 </script>
 
 <Dialog.Root bind:open>
-    <Dialog.Content class="flex max-h-[85vh] w-full max-w-5xl flex-col overflow-hidden">
+    <Dialog.Content class="flex max-h-[85vh] w-5xl !max-w-none flex-col overflow-hidden">
         <Dialog.Header>
             <Dialog.Title>Import MIDI</Dialog.Title>
             <Dialog.Description>
@@ -479,11 +479,11 @@
             />
             <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
                 <div>
-                    <p class="text-sm font-medium text-muted-foreground">Selected file</p>
+                    <p class="text-sm font-medium text-wrap text-muted-foreground">Selected file</p>
                     {#if midiFileName}
-                        <p class="text-sm font-medium">{midiFileName}</p>
+                        <p class="text-sm font-medium text-wrap">{midiFileName}</p>
                     {:else}
-                        <p class="text-sm text-muted-foreground">No file selected</p>
+                        <p class="text-sm text-wrap text-muted-foreground">No file selected</p>
                     {/if}
                 </div>
                 <Button variant="outline" onclick={openFilePicker} disabled={isLoading}>
@@ -499,7 +499,7 @@
 
             {#if errorMessage}
                 <div
-                    class="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive"
+                    class="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-wrap text-destructive"
                 >
                     {errorMessage}
                 </div>
@@ -507,26 +507,28 @@
 
             {#if assignments.length > 0}
                 <div class="rounded-md border">
-                    <Table class="border-collapse text-sm">
+                    <Table class="table-fixed border-collapse text-sm">
                         <TableHeader class="bg-muted/40 text-muted-foreground">
                             <TableRow class="border-border/80">
-                                <TableHead class="w-32 px-4 py-2">MIDI Channel</TableHead>
-                                <TableHead class="w-[30rem] px-4 py-2">Track</TableHead>
-                                <TableHead class="w-[26rem] px-4 py-2">Target</TableHead>
-                                <TableHead class="w-52 px-4 py-2">Transpose</TableHead>
+                                <TableHead class="w-20 max-w-32 px-4 py-2">MIDI Ch.</TableHead>
+                                <TableHead class="max-w-[30rem] px-4 py-2">Track</TableHead>
+                                <TableHead class="max-w-[26rem] px-4 py-2">Target</TableHead>
+                                <TableHead class="max-w-52 px-4 py-2">Transpose</TableHead>
                             </TableRow>
                         </TableHeader>
                         <TableBody>
                             {#each assignments as assignment, index}
                                 <TableRow class="border-border/60">
                                     <TableCell
-                                        class="w-24 px-4 py-3 align-top font-mono text-sm font-medium"
+                                        class="w-20 max-w-32 px-4 py-3 align-top font-mono text-sm font-medium"
                                     >
                                         {assignment.channelNumber}
                                     </TableCell>
-                                    <TableCell class="w-[26rem] px-4 py-3 align-top">
-                                        <p class="font-medium">{assignment.name}</p>
-                                        <p class="text-xs text-muted-foreground">
+                                    <TableCell class="max-w-[30rem] px-4 py-3 align-top">
+                                        <p class="font-medium break-words">{assignment.name}</p>
+                                        <p
+                                            class="text-xs text-wrap break-words whitespace-normal text-muted-foreground"
+                                        >
                                             {(
                                                 assignment.track.instrument.name ||
                                                 'Unknown instrument'
@@ -534,34 +536,32 @@
                                             · {describeTrack(assignment)}
                                         </p>
                                     </TableCell>
-                                    <TableCell class="w-[22rem] px-4 py-3 align-top">
+                                    <TableCell class="max-w-[26rem] px-4 py-3 align-top">
                                         <div class="flex flex-col gap-2">
-                                            {#if assignment.track.channel === 9}
-                                                <div class="flex flex-wrap gap-2">
-                                                    <Button
-                                                        size="sm"
-                                                        variant={assignment.mode === 'instrument'
-                                                            ? 'default'
-                                                            : 'outline'}
-                                                        onclick={() => setMode(index, 'instrument')}
-                                                    >
-                                                        Instrument
-                                                    </Button>
-                                                    <Button
-                                                        size="sm"
-                                                        variant={assignment.mode === 'percussion'
-                                                            ? 'default'
-                                                            : 'outline'}
-                                                        onclick={() => setMode(index, 'percussion')}
-                                                    >
-                                                        Percussion
-                                                    </Button>
-                                                </div>
-                                            {/if}
+                                            <div class="flex flex-wrap gap-2">
+                                                <Button
+                                                    size="sm"
+                                                    variant={assignment.mode === 'instrument'
+                                                        ? 'default'
+                                                        : 'outline'}
+                                                    onclick={() => setMode(index, 'instrument')}
+                                                >
+                                                    Instrument
+                                                </Button>
+                                                <Button
+                                                    size="sm"
+                                                    variant={assignment.mode === 'percussion'
+                                                        ? 'default'
+                                                        : 'outline'}
+                                                    onclick={() => setMode(index, 'percussion')}
+                                                >
+                                                    Percussion
+                                                </Button>
+                                            </div>
 
                                             {#if assignment.mode === 'percussion' && assignment.percussionMapping}
                                                 <div
-                                                    class="w-full rounded-md border border-dashed px-3 py-2 text-xs text-muted-foreground"
+                                                    class="w-full rounded-md border border-dashed px-3 py-2 text-xs text-wrap text-muted-foreground"
                                                 >
                                                     {describePercussion(
                                                         assignment.percussionMapping
@@ -593,7 +593,7 @@
                                             {/if}
                                         </div>
                                     </TableCell>
-                                    <TableCell class="w-52 px-4 py-3 align-top">
+                                    <TableCell class="max-w-52 px-4 py-3 align-top">
                                         {@const rawStats = computeOutOfRangeNotes(
                                             assignment.track,
                                             assignment.transpose
@@ -646,46 +646,11 @@
                                         )}
 
                                         <div class="flex flex-col gap-1.5">
-                                            <div class="flex flex-wrap items-center gap-2">
-                                                <button
-                                                    type="button"
-                                                    class="flex h-8 w-8 items-center justify-center rounded-md border border-border bg-background text-foreground transition hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:bg-background"
-                                                    aria-label="Transpose down one octave"
-                                                    title="Transpose down by 1 octave"
-                                                    disabled={!isInstrument}
-                                                    onclick={() =>
-                                                        adjustTranspose(index, -OCTAVE_INTERVAL)}
-                                                >
-                                                    <ArrowDownIcon class="size-4" />
-                                                </button>
-                                                <button
-                                                    type="button"
-                                                    class="flex h-8 w-8 items-center justify-center rounded-md border border-border bg-background text-xs font-semibold text-foreground transition hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:bg-background"
-                                                    aria-label="Transpose down one semitone"
-                                                    title="Transpose down by 1 semitone"
-                                                    disabled={!isInstrument}
-                                                    onclick={() => adjustTranspose(index, -1)}
-                                                >
-                                                    &lt;
-                                                </button>
-                                                <div
-                                                    class="min-w-[9.5rem] text-center text-sm font-medium text-foreground"
-                                                >
-                                                    {transposeDisplay}
-                                                </div>
-                                                <button
-                                                    type="button"
-                                                    class="flex h-8 w-8 items-center justify-center rounded-md border border-border bg-background text-xs font-semibold text-foreground transition hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:bg-background"
-                                                    aria-label="Transpose up one semitone"
-                                                    title="Transpose up by 1 semitone"
-                                                    disabled={!isInstrument}
-                                                    onclick={() => adjustTranspose(index, 1)}
-                                                >
-                                                    &gt;
-                                                </button>
-                                                <button
-                                                    type="button"
-                                                    class="flex h-8 w-8 items-center justify-center rounded-md border border-border bg-background text-foreground transition hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:bg-background"
+                                            <div class="flex flex-col gap-2">
+                                                <Button
+                                                    variant="outline"
+                                                    size="sm"
+                                                    class="h-8 w-full justify-center gap-2"
                                                     aria-label="Transpose up one octave"
                                                     title="Transpose up by 1 octave"
                                                     disabled={!isInstrument}
@@ -693,10 +658,31 @@
                                                         adjustTranspose(index, OCTAVE_INTERVAL)}
                                                 >
                                                     <ArrowUpIcon class="size-4" />
-                                                </button>
+                                                    +1 Octave
+                                                </Button>
+
+                                                <div
+                                                    class="py-1 text-center text-sm font-medium text-foreground"
+                                                >
+                                                    {transposeDisplay}
+                                                </div>
+
+                                                <Button
+                                                    variant="outline"
+                                                    size="sm"
+                                                    class="h-8 w-full justify-center gap-2"
+                                                    aria-label="Transpose down one octave"
+                                                    title="Transpose down by 1 octave"
+                                                    disabled={!isInstrument}
+                                                    onclick={() =>
+                                                        adjustTranspose(index, -OCTAVE_INTERVAL)}
+                                                >
+                                                    <ArrowDownIcon class="size-4" />
+                                                    -1 Octave
+                                                </Button>
 
                                                 <label
-                                                    class="ml-auto flex cursor-pointer items-center gap-2 text-xs text-muted-foreground select-none"
+                                                    class="flex cursor-pointer items-center gap-2 text-xs text-muted-foreground select-none"
                                                 >
                                                     <Checkbox
                                                         checked={transposeWithinRange}
@@ -715,17 +701,19 @@
 
                                             {#if hasDisplayOverflow}
                                                 <p
-                                                    class="text-xs text-amber-600 dark:text-amber-400"
+                                                    class="text-xs text-wrap text-amber-600 dark:text-amber-400"
                                                 >
                                                     {displaySummary}
                                                 </p>
                                             {:else}
                                                 <div
-                                                    class="space-y-0.5 text-xs text-muted-foreground"
+                                                    class="space-y-0.5 text-xs text-wrap text-muted-foreground"
                                                 >
                                                     <p>All notes within Noteblock range.</p>
                                                     {#if transposeWithinRange && hasRawOverflow}
-                                                        <p class="text-muted-foreground/80">
+                                                        <p
+                                                            class="text-wrap text-muted-foreground/80"
+                                                        >
                                                             {rawSummary} will be shifted to the nearest
                                                             octave when importing.
                                                         </p>
@@ -734,7 +722,7 @@
                                             {/if}
 
                                             {#if !isInstrument}
-                                                <p class="text-xs text-muted-foreground">
+                                                <p class="text-xs text-wrap text-muted-foreground">
                                                     Transpose applies when importing as an
                                                     instrument.
                                                 </p>
@@ -748,7 +736,7 @@
                 </div>
             {:else}
                 <div
-                    class="rounded-md border border-dashed px-6 py-12 text-center text-sm text-muted-foreground"
+                    class="rounded-md border border-dashed px-6 py-12 text-center text-sm text-wrap text-muted-foreground"
                 >
                     {#if isLoading}
                         Reading MIDI file...

--- a/src/lib/components/editor/midi-import-dialog.svelte
+++ b/src/lib/components/editor/midi-import-dialog.svelte
@@ -665,6 +665,33 @@
                                                     class="py-1 text-center text-sm font-medium text-foreground"
                                                 >
                                                     {transposeDisplay}
+                                                    {#if hasDisplayOverflow}
+                                                        <p
+                                                            class="text-xs text-wrap text-amber-600 dark:text-amber-400"
+                                                        >
+                                                            {displaySummary}
+                                                        </p>
+                                                    {:else}
+                                                        <div
+                                                            class="space-y-0.5 text-xs text-wrap text-muted-foreground"
+                                                        >
+                                                            {#if transposeWithinRange}
+                                                                <p
+                                                                    class="text-wrap text-muted-foreground/80"
+                                                                >
+                                                                    <span class="font-bold"
+                                                                        >{rawSummary}</span
+                                                                    > will be shifted to the nearest
+                                                                    octave when importing.
+                                                                </p>
+                                                            {:else}
+                                                                <p>
+                                                                    All notes within Noteblock
+                                                                    range. ({rawSummary})
+                                                                </p>
+                                                            {/if}
+                                                        </div>
+                                                    {/if}
                                                 </div>
 
                                                 <Button
@@ -698,28 +725,6 @@
                                                     </span>
                                                 </label>
                                             </div>
-
-                                            {#if hasDisplayOverflow}
-                                                <p
-                                                    class="text-xs text-wrap text-amber-600 dark:text-amber-400"
-                                                >
-                                                    {displaySummary}
-                                                </p>
-                                            {:else}
-                                                <div
-                                                    class="space-y-0.5 text-xs text-wrap text-muted-foreground"
-                                                >
-                                                    <p>All notes within Noteblock range.</p>
-                                                    {#if transposeWithinRange && hasRawOverflow}
-                                                        <p
-                                                            class="text-wrap text-muted-foreground/80"
-                                                        >
-                                                            {rawSummary} will be shifted to the nearest
-                                                            octave when importing.
-                                                        </p>
-                                                    {/if}
-                                                </div>
-                                            {/if}
 
                                             {#if !isInstrument}
                                                 <p class="text-xs text-wrap text-muted-foreground">

--- a/src/lib/components/editor/midi-import-dialog.svelte
+++ b/src/lib/components/editor/midi-import-dialog.svelte
@@ -23,6 +23,8 @@
         Instrument,
         INSTRUMENT_ICONS,
         INSTRUMENT_NAMES,
+        NOTEBLOCK_HIGHEST_KEY_IN_MIDI,
+        NOTEBLOCK_LOWEST_KEY_IN_MIDI,
         type NoteChannel,
         type Song,
         type TempoChannel
@@ -355,7 +357,9 @@
                     const channel = intoChannelAsInstrument(
                         assignment.track,
                         assignment.instrument,
-                        tickScale
+                        tickScale,
+                        assignment.transpose,
+                        assignment.transposeWithinRange
                     );
                     channel.name = assignment.name;
                     noteChannels.push(channel);
@@ -508,6 +512,7 @@
                                 <TableHead class="w-32 px-4 py-2">MIDI Channel</TableHead>
                                 <TableHead class="w-[30rem] px-4 py-2">Track</TableHead>
                                 <TableHead class="w-[26rem] px-4 py-2">Target</TableHead>
+                                <TableHead class="w-52 px-4 py-2">Transpose</TableHead>
                             </TableRow>
                         </TableHeader>
                         <TableBody>

--- a/src/lib/components/ui/checkbox/checkbox.svelte
+++ b/src/lib/components/ui/checkbox/checkbox.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+	import { Checkbox as CheckboxPrimitive } from "bits-ui";
+	import CheckIcon from "@lucide/svelte/icons/check";
+	import MinusIcon from "@lucide/svelte/icons/minus";
+	import { cn, type WithoutChildrenOrChild } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		checked = $bindable(false),
+		indeterminate = $bindable(false),
+		class: className,
+		...restProps
+	}: WithoutChildrenOrChild<CheckboxPrimitive.RootProps> = $props();
+</script>
+
+<CheckboxPrimitive.Root
+	bind:ref
+	data-slot="checkbox"
+	class={cn(
+		"border-input dark:bg-input/30 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:data-[state=checked]:bg-primary data-[state=checked]:border-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive shadow-xs peer flex size-4 shrink-0 items-center justify-center rounded-[4px] border outline-none transition-shadow focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
+		className
+	)}
+	bind:checked
+	bind:indeterminate
+	{...restProps}
+>
+	{#snippet children({ checked, indeterminate })}
+		<div data-slot="checkbox-indicator" class="text-current transition-none">
+			{#if checked}
+				<CheckIcon class="size-3.5" />
+			{:else if indeterminate}
+				<MinusIcon class="size-3.5" />
+			{/if}
+		</div>
+	{/snippet}
+</CheckboxPrimitive.Root>

--- a/src/lib/components/ui/checkbox/checkbox.svelte
+++ b/src/lib/components/ui/checkbox/checkbox.svelte
@@ -1,36 +1,36 @@
 <script lang="ts">
-	import { Checkbox as CheckboxPrimitive } from "bits-ui";
-	import CheckIcon from "@lucide/svelte/icons/check";
-	import MinusIcon from "@lucide/svelte/icons/minus";
-	import { cn, type WithoutChildrenOrChild } from "$lib/utils.js";
+    import { Checkbox as CheckboxPrimitive } from 'bits-ui';
+    import CheckIcon from '@lucide/svelte/icons/check';
+    import MinusIcon from '@lucide/svelte/icons/minus';
+    import { cn, type WithoutChildrenOrChild } from '$lib/utils.js';
 
-	let {
-		ref = $bindable(null),
-		checked = $bindable(false),
-		indeterminate = $bindable(false),
-		class: className,
-		...restProps
-	}: WithoutChildrenOrChild<CheckboxPrimitive.RootProps> = $props();
+    let {
+        ref = $bindable(null),
+        checked = $bindable(false),
+        indeterminate = $bindable(false),
+        class: className,
+        ...restProps
+    }: WithoutChildrenOrChild<CheckboxPrimitive.RootProps> = $props();
 </script>
 
 <CheckboxPrimitive.Root
-	bind:ref
-	data-slot="checkbox"
-	class={cn(
-		"border-input dark:bg-input/30 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:data-[state=checked]:bg-primary data-[state=checked]:border-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive shadow-xs peer flex size-4 shrink-0 items-center justify-center rounded-[4px] border outline-none transition-shadow focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
-		className
-	)}
-	bind:checked
-	bind:indeterminate
-	{...restProps}
+    bind:ref
+    data-slot="checkbox"
+    class={cn(
+        'peer flex size-4 shrink-0 items-center justify-center rounded-[4px] border border-input shadow-xs transition-shadow outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 data-[state=checked]:border-primary data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:bg-input/30 dark:aria-invalid:ring-destructive/40 dark:data-[state=checked]:bg-primary',
+        className
+    )}
+    bind:checked
+    bind:indeterminate
+    {...restProps}
 >
-	{#snippet children({ checked, indeterminate })}
-		<div data-slot="checkbox-indicator" class="text-current transition-none">
-			{#if checked}
-				<CheckIcon class="size-3.5" />
-			{:else if indeterminate}
-				<MinusIcon class="size-3.5" />
-			{/if}
-		</div>
-	{/snippet}
+    {#snippet children({ checked, indeterminate })}
+        <div data-slot="checkbox-indicator" class="text-current transition-none">
+            {#if checked}
+                <CheckIcon class="size-3.5" />
+            {:else if indeterminate}
+                <MinusIcon class="size-3.5" />
+            {/if}
+        </div>
+    {/snippet}
 </CheckboxPrimitive.Root>

--- a/src/lib/components/ui/checkbox/index.ts
+++ b/src/lib/components/ui/checkbox/index.ts
@@ -1,0 +1,6 @@
+import Root from "./checkbox.svelte";
+export {
+	Root,
+	//
+	Root as Checkbox,
+};

--- a/src/lib/components/ui/checkbox/index.ts
+++ b/src/lib/components/ui/checkbox/index.ts
@@ -1,6 +1,6 @@
-import Root from "./checkbox.svelte";
+import Root from './checkbox.svelte';
 export {
-	Root,
-	//
-	Root as Checkbox,
+    Root,
+    //
+    Root as Checkbox
 };

--- a/src/lib/components/ui/table/index.ts
+++ b/src/lib/components/ui/table/index.ts
@@ -1,0 +1,28 @@
+import Root from "./table.svelte";
+import Body from "./table-body.svelte";
+import Caption from "./table-caption.svelte";
+import Cell from "./table-cell.svelte";
+import Footer from "./table-footer.svelte";
+import Head from "./table-head.svelte";
+import Header from "./table-header.svelte";
+import Row from "./table-row.svelte";
+
+export {
+	Root,
+	Body,
+	Caption,
+	Cell,
+	Footer,
+	Head,
+	Header,
+	Row,
+	//
+	Root as Table,
+	Body as TableBody,
+	Caption as TableCaption,
+	Cell as TableCell,
+	Footer as TableFooter,
+	Head as TableHead,
+	Header as TableHeader,
+	Row as TableRow,
+};

--- a/src/lib/components/ui/table/index.ts
+++ b/src/lib/components/ui/table/index.ts
@@ -1,28 +1,28 @@
-import Root from "./table.svelte";
-import Body from "./table-body.svelte";
-import Caption from "./table-caption.svelte";
-import Cell from "./table-cell.svelte";
-import Footer from "./table-footer.svelte";
-import Head from "./table-head.svelte";
-import Header from "./table-header.svelte";
-import Row from "./table-row.svelte";
+import Root from './table.svelte';
+import Body from './table-body.svelte';
+import Caption from './table-caption.svelte';
+import Cell from './table-cell.svelte';
+import Footer from './table-footer.svelte';
+import Head from './table-head.svelte';
+import Header from './table-header.svelte';
+import Row from './table-row.svelte';
 
 export {
-	Root,
-	Body,
-	Caption,
-	Cell,
-	Footer,
-	Head,
-	Header,
-	Row,
-	//
-	Root as Table,
-	Body as TableBody,
-	Caption as TableCaption,
-	Cell as TableCell,
-	Footer as TableFooter,
-	Head as TableHead,
-	Header as TableHeader,
-	Row as TableRow,
+    Root,
+    Body,
+    Caption,
+    Cell,
+    Footer,
+    Head,
+    Header,
+    Row,
+    //
+    Root as Table,
+    Body as TableBody,
+    Caption as TableCaption,
+    Cell as TableCell,
+    Footer as TableFooter,
+    Head as TableHead,
+    Header as TableHeader,
+    Row as TableRow
 };

--- a/src/lib/components/ui/table/table-body.svelte
+++ b/src/lib/components/ui/table/table-body.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import { cn, type WithElementRef } from "$lib/utils.js";
+	import type { HTMLAttributes } from "svelte/elements";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLTableSectionElement>> = $props();
+</script>
+
+<tbody
+	bind:this={ref}
+	data-slot="table-body"
+	class={cn("[&_tr:last-child]:border-0", className)}
+	{...restProps}
+>
+	{@render children?.()}
+</tbody>

--- a/src/lib/components/ui/table/table-body.svelte
+++ b/src/lib/components/ui/table/table-body.svelte
@@ -1,20 +1,20 @@
 <script lang="ts">
-	import { cn, type WithElementRef } from "$lib/utils.js";
-	import type { HTMLAttributes } from "svelte/elements";
+    import { cn, type WithElementRef } from '$lib/utils.js';
+    import type { HTMLAttributes } from 'svelte/elements';
 
-	let {
-		ref = $bindable(null),
-		class: className,
-		children,
-		...restProps
-	}: WithElementRef<HTMLAttributes<HTMLTableSectionElement>> = $props();
+    let {
+        ref = $bindable(null),
+        class: className,
+        children,
+        ...restProps
+    }: WithElementRef<HTMLAttributes<HTMLTableSectionElement>> = $props();
 </script>
 
 <tbody
-	bind:this={ref}
-	data-slot="table-body"
-	class={cn("[&_tr:last-child]:border-0", className)}
-	{...restProps}
+    bind:this={ref}
+    data-slot="table-body"
+    class={cn('[&_tr:last-child]:border-0', className)}
+    {...restProps}
 >
-	{@render children?.()}
+    {@render children?.()}
 </tbody>

--- a/src/lib/components/ui/table/table-caption.svelte
+++ b/src/lib/components/ui/table/table-caption.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import { cn, type WithElementRef } from "$lib/utils.js";
+	import type { HTMLAttributes } from "svelte/elements";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLElement>> = $props();
+</script>
+
+<caption
+	bind:this={ref}
+	data-slot="table-caption"
+	class={cn("text-muted-foreground mt-4 text-sm", className)}
+	{...restProps}
+>
+	{@render children?.()}
+</caption>

--- a/src/lib/components/ui/table/table-caption.svelte
+++ b/src/lib/components/ui/table/table-caption.svelte
@@ -1,20 +1,20 @@
 <script lang="ts">
-	import { cn, type WithElementRef } from "$lib/utils.js";
-	import type { HTMLAttributes } from "svelte/elements";
+    import { cn, type WithElementRef } from '$lib/utils.js';
+    import type { HTMLAttributes } from 'svelte/elements';
 
-	let {
-		ref = $bindable(null),
-		class: className,
-		children,
-		...restProps
-	}: WithElementRef<HTMLAttributes<HTMLElement>> = $props();
+    let {
+        ref = $bindable(null),
+        class: className,
+        children,
+        ...restProps
+    }: WithElementRef<HTMLAttributes<HTMLElement>> = $props();
 </script>
 
 <caption
-	bind:this={ref}
-	data-slot="table-caption"
-	class={cn("text-muted-foreground mt-4 text-sm", className)}
-	{...restProps}
+    bind:this={ref}
+    data-slot="table-caption"
+    class={cn('mt-4 text-sm text-muted-foreground', className)}
+    {...restProps}
 >
-	{@render children?.()}
+    {@render children?.()}
 </caption>

--- a/src/lib/components/ui/table/table-cell.svelte
+++ b/src/lib/components/ui/table/table-cell.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+	import { cn, type WithElementRef } from "$lib/utils.js";
+	import type { HTMLTdAttributes } from "svelte/elements";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLTdAttributes> = $props();
+</script>
+
+<td
+	bind:this={ref}
+	data-slot="table-cell"
+	class={cn(
+		"whitespace-nowrap bg-clip-padding p-2 align-middle [&:has([role=checkbox])]:pr-0",
+		className
+	)}
+	{...restProps}
+>
+	{@render children?.()}
+</td>

--- a/src/lib/components/ui/table/table-cell.svelte
+++ b/src/lib/components/ui/table/table-cell.svelte
@@ -1,23 +1,23 @@
 <script lang="ts">
-	import { cn, type WithElementRef } from "$lib/utils.js";
-	import type { HTMLTdAttributes } from "svelte/elements";
+    import { cn, type WithElementRef } from '$lib/utils.js';
+    import type { HTMLTdAttributes } from 'svelte/elements';
 
-	let {
-		ref = $bindable(null),
-		class: className,
-		children,
-		...restProps
-	}: WithElementRef<HTMLTdAttributes> = $props();
+    let {
+        ref = $bindable(null),
+        class: className,
+        children,
+        ...restProps
+    }: WithElementRef<HTMLTdAttributes> = $props();
 </script>
 
 <td
-	bind:this={ref}
-	data-slot="table-cell"
-	class={cn(
-		"whitespace-nowrap bg-clip-padding p-2 align-middle [&:has([role=checkbox])]:pr-0",
-		className
-	)}
-	{...restProps}
+    bind:this={ref}
+    data-slot="table-cell"
+    class={cn(
+        'bg-clip-padding p-2 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0',
+        className
+    )}
+    {...restProps}
 >
-	{@render children?.()}
+    {@render children?.()}
 </td>

--- a/src/lib/components/ui/table/table-footer.svelte
+++ b/src/lib/components/ui/table/table-footer.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import { cn, type WithElementRef } from "$lib/utils.js";
+	import type { HTMLAttributes } from "svelte/elements";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLTableSectionElement>> = $props();
+</script>
+
+<tfoot
+	bind:this={ref}
+	data-slot="table-footer"
+	class={cn("bg-muted/50 border-t font-medium [&>tr]:last:border-b-0", className)}
+	{...restProps}
+>
+	{@render children?.()}
+</tfoot>

--- a/src/lib/components/ui/table/table-footer.svelte
+++ b/src/lib/components/ui/table/table-footer.svelte
@@ -1,20 +1,20 @@
 <script lang="ts">
-	import { cn, type WithElementRef } from "$lib/utils.js";
-	import type { HTMLAttributes } from "svelte/elements";
+    import { cn, type WithElementRef } from '$lib/utils.js';
+    import type { HTMLAttributes } from 'svelte/elements';
 
-	let {
-		ref = $bindable(null),
-		class: className,
-		children,
-		...restProps
-	}: WithElementRef<HTMLAttributes<HTMLTableSectionElement>> = $props();
+    let {
+        ref = $bindable(null),
+        class: className,
+        children,
+        ...restProps
+    }: WithElementRef<HTMLAttributes<HTMLTableSectionElement>> = $props();
 </script>
 
 <tfoot
-	bind:this={ref}
-	data-slot="table-footer"
-	class={cn("bg-muted/50 border-t font-medium [&>tr]:last:border-b-0", className)}
-	{...restProps}
+    bind:this={ref}
+    data-slot="table-footer"
+    class={cn('border-t bg-muted/50 font-medium [&>tr]:last:border-b-0', className)}
+    {...restProps}
 >
-	{@render children?.()}
+    {@render children?.()}
 </tfoot>

--- a/src/lib/components/ui/table/table-head.svelte
+++ b/src/lib/components/ui/table/table-head.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+	import { cn, type WithElementRef } from "$lib/utils.js";
+	import type { HTMLThAttributes } from "svelte/elements";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLThAttributes> = $props();
+</script>
+
+<th
+	bind:this={ref}
+	data-slot="table-head"
+	class={cn(
+		"text-foreground h-10 whitespace-nowrap bg-clip-padding px-2 text-left align-middle font-medium [&:has([role=checkbox])]:pr-0",
+		className
+	)}
+	{...restProps}
+>
+	{@render children?.()}
+</th>

--- a/src/lib/components/ui/table/table-head.svelte
+++ b/src/lib/components/ui/table/table-head.svelte
@@ -1,23 +1,23 @@
 <script lang="ts">
-	import { cn, type WithElementRef } from "$lib/utils.js";
-	import type { HTMLThAttributes } from "svelte/elements";
+    import { cn, type WithElementRef } from '$lib/utils.js';
+    import type { HTMLThAttributes } from 'svelte/elements';
 
-	let {
-		ref = $bindable(null),
-		class: className,
-		children,
-		...restProps
-	}: WithElementRef<HTMLThAttributes> = $props();
+    let {
+        ref = $bindable(null),
+        class: className,
+        children,
+        ...restProps
+    }: WithElementRef<HTMLThAttributes> = $props();
 </script>
 
 <th
-	bind:this={ref}
-	data-slot="table-head"
-	class={cn(
-		"text-foreground h-10 whitespace-nowrap bg-clip-padding px-2 text-left align-middle font-medium [&:has([role=checkbox])]:pr-0",
-		className
-	)}
-	{...restProps}
+    bind:this={ref}
+    data-slot="table-head"
+    class={cn(
+        'h-10 bg-clip-padding px-2 text-left align-middle font-medium whitespace-nowrap text-foreground [&:has([role=checkbox])]:pr-0',
+        className
+    )}
+    {...restProps}
 >
-	{@render children?.()}
+    {@render children?.()}
 </th>

--- a/src/lib/components/ui/table/table-header.svelte
+++ b/src/lib/components/ui/table/table-header.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import { cn, type WithElementRef } from "$lib/utils.js";
+	import type { HTMLAttributes } from "svelte/elements";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLTableSectionElement>> = $props();
+</script>
+
+<thead
+	bind:this={ref}
+	data-slot="table-header"
+	class={cn("[&_tr]:border-b", className)}
+	{...restProps}
+>
+	{@render children?.()}
+</thead>

--- a/src/lib/components/ui/table/table-header.svelte
+++ b/src/lib/components/ui/table/table-header.svelte
@@ -1,20 +1,20 @@
 <script lang="ts">
-	import { cn, type WithElementRef } from "$lib/utils.js";
-	import type { HTMLAttributes } from "svelte/elements";
+    import { cn, type WithElementRef } from '$lib/utils.js';
+    import type { HTMLAttributes } from 'svelte/elements';
 
-	let {
-		ref = $bindable(null),
-		class: className,
-		children,
-		...restProps
-	}: WithElementRef<HTMLAttributes<HTMLTableSectionElement>> = $props();
+    let {
+        ref = $bindable(null),
+        class: className,
+        children,
+        ...restProps
+    }: WithElementRef<HTMLAttributes<HTMLTableSectionElement>> = $props();
 </script>
 
 <thead
-	bind:this={ref}
-	data-slot="table-header"
-	class={cn("[&_tr]:border-b", className)}
-	{...restProps}
+    bind:this={ref}
+    data-slot="table-header"
+    class={cn('[&_tr]:border-b', className)}
+    {...restProps}
 >
-	{@render children?.()}
+    {@render children?.()}
 </thead>

--- a/src/lib/components/ui/table/table-row.svelte
+++ b/src/lib/components/ui/table/table-row.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+	import { cn, type WithElementRef } from "$lib/utils.js";
+	import type { HTMLAttributes } from "svelte/elements";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLTableRowElement>> = $props();
+</script>
+
+<tr
+	bind:this={ref}
+	data-slot="table-row"
+	class={cn(
+		"hover:[&,&>svelte-css-wrapper]:[&>th,td]:bg-muted/50 data-[state=selected]:bg-muted border-b transition-colors",
+		className
+	)}
+	{...restProps}
+>
+	{@render children?.()}
+</tr>

--- a/src/lib/components/ui/table/table-row.svelte
+++ b/src/lib/components/ui/table/table-row.svelte
@@ -1,23 +1,23 @@
 <script lang="ts">
-	import { cn, type WithElementRef } from "$lib/utils.js";
-	import type { HTMLAttributes } from "svelte/elements";
+    import { cn, type WithElementRef } from '$lib/utils.js';
+    import type { HTMLAttributes } from 'svelte/elements';
 
-	let {
-		ref = $bindable(null),
-		class: className,
-		children,
-		...restProps
-	}: WithElementRef<HTMLAttributes<HTMLTableRowElement>> = $props();
+    let {
+        ref = $bindable(null),
+        class: className,
+        children,
+        ...restProps
+    }: WithElementRef<HTMLAttributes<HTMLTableRowElement>> = $props();
 </script>
 
 <tr
-	bind:this={ref}
-	data-slot="table-row"
-	class={cn(
-		"hover:[&,&>svelte-css-wrapper]:[&>th,td]:bg-muted/50 data-[state=selected]:bg-muted border-b transition-colors",
-		className
-	)}
-	{...restProps}
+    bind:this={ref}
+    data-slot="table-row"
+    class={cn(
+        'border-b transition-colors data-[state=selected]:bg-muted hover:[&,&>svelte-css-wrapper]:[&>th,td]:bg-muted/50',
+        className
+    )}
+    {...restProps}
 >
-	{@render children?.()}
+    {@render children?.()}
 </tr>

--- a/src/lib/components/ui/table/table.svelte
+++ b/src/lib/components/ui/table/table.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+	import type { HTMLTableAttributes } from "svelte/elements";
+	import { cn, type WithElementRef } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLTableAttributes> = $props();
+</script>
+
+<div data-slot="table-container" class="relative w-full overflow-x-auto">
+	<table
+		bind:this={ref}
+		data-slot="table"
+		class={cn("w-full caption-bottom text-sm", className)}
+		{...restProps}
+	>
+		{@render children?.()}
+	</table>
+</div>

--- a/src/lib/components/ui/table/table.svelte
+++ b/src/lib/components/ui/table/table.svelte
@@ -1,22 +1,22 @@
 <script lang="ts">
-	import type { HTMLTableAttributes } from "svelte/elements";
-	import { cn, type WithElementRef } from "$lib/utils.js";
+    import type { HTMLTableAttributes } from 'svelte/elements';
+    import { cn, type WithElementRef } from '$lib/utils.js';
 
-	let {
-		ref = $bindable(null),
-		class: className,
-		children,
-		...restProps
-	}: WithElementRef<HTMLTableAttributes> = $props();
+    let {
+        ref = $bindable(null),
+        class: className,
+        children,
+        ...restProps
+    }: WithElementRef<HTMLTableAttributes> = $props();
 </script>
 
 <div data-slot="table-container" class="relative w-full overflow-x-auto">
-	<table
-		bind:this={ref}
-		data-slot="table"
-		class={cn("w-full caption-bottom text-sm", className)}
-		{...restProps}
-	>
-		{@render children?.()}
-	</table>
+    <table
+        bind:this={ref}
+        data-slot="table"
+        class={cn('w-full caption-bottom text-sm', className)}
+        {...restProps}
+    >
+        {@render children?.()}
+    </table>
 </div>

--- a/src/lib/midi.ts
+++ b/src/lib/midi.ts
@@ -1,0 +1,146 @@
+import type { TrackJSON } from '@tonejs/midi';
+import type { Note, NoteChannel } from './types.js';
+import { Instrument } from './types.js';
+
+export interface PercussionTarget {
+    instrument: Instrument;
+    key: number;
+}
+
+export type PercussionMapping = Record<number, PercussionTarget>;
+
+export function guessInstrumentForTrack(track: TrackJSON): Instrument {
+    const program = track.instrument.number ?? 0;
+
+    if (track.channel === 9) {
+        return Instrument.BassDrum;
+    }
+
+    if (program >= 8 && program <= 15) return Instrument.Bell; // Chromatic percussion
+    if (program >= 16 && program <= 23) return Instrument.Chime; // Organs / sustained
+    if (program >= 24 && program <= 31) return Instrument.Guitar; // Guitars
+    if (program >= 32 && program <= 39) return Instrument.DoubleBass; // Basses
+    if (program >= 40 && program <= 47) return Instrument.Flute; // Strings
+    if (program >= 48 && program <= 55) return Instrument.Flute; // Ensemble strings
+    if (program >= 56 && program <= 63) return Instrument.Didgeridoo; // Brass
+    if (program >= 64 && program <= 71) return Instrument.Flute; // Reeds
+    if (program >= 72 && program <= 79) return Instrument.Flute; // Pipes
+    if (program >= 80 && program <= 95) return Instrument.Bit; // Synth leads/pads
+    if (program >= 96 && program <= 103) return Instrument.Pling; // FX
+    if (program >= 104 && program <= 111) return Instrument.Banjo; // Ethnic
+    if (program >= 112 && program <= 119) return Instrument.SnareDrum; // Percussive
+    if (program >= 120) return Instrument.Click; // Sound effects
+
+    return Instrument.Piano;
+}
+
+export function createDefaultPercussionMapping(track: TrackJSON): PercussionMapping {
+    const mapping: PercussionMapping = {};
+
+    for (const note of track.notes) {
+        const midi = note.midi;
+        if (mapping[midi]) continue;
+
+        mapping[midi] = {
+            instrument: mapPercussionInstrument(midi),
+            key: clampToRange(Math.round(midi - 21), 0, 87)
+        };
+    }
+
+    return mapping;
+}
+
+function mapPercussionInstrument(midi: number): Instrument {
+    if (midi <= 36) return Instrument.BassDrum;
+    if (midi <= 40) return Instrument.SnareDrum;
+    if (midi <= 46) return Instrument.Click;
+    if (midi <= 52) return Instrument.Bell;
+    if (midi <= 60) return Instrument.Guitar;
+    if (midi <= 72) return Instrument.Flute;
+    if (midi <= 84) return Instrument.Bit;
+    return Instrument.Pling;
+}
+
+function clampToRange(value: number, min: number, max: number): number {
+    if (Number.isNaN(value) || !Number.isFinite(value)) return min;
+    return Math.max(min, Math.min(max, value));
+}
+
+export function intoChannelAsInstrument(
+    midiTrack: TrackJSON,
+    instrument: Instrument,
+    tickScale = 1
+): NoteChannel {
+    const notes: Note[] = midiTrack.notes
+        .map((midiNote) => ({
+            tick: Math.max(0, Math.round(midiNote.ticks * tickScale)),
+            key: clampToRange(Math.round(midiNote.midi - 21), 0, 87),
+            velocity: clampToRange(Math.round(midiNote.velocity * 100), 0, 100),
+            pitch: 0 // Default pitch adjustment
+        }))
+        .sort((a, b) => a.tick - b.tick);
+
+    const sectionLength = notes.length ? Math.max(...notes.map((n) => n.tick)) + 1 : 0;
+
+    return {
+        kind: 'note',
+        name: midiTrack.name || `${instrument} Track`,
+        sections: [
+            {
+                startingTick: 0,
+                length: sectionLength,
+                notes,
+                name: 'Main Section'
+            }
+        ],
+        pan: 0,
+        instrument,
+        isMuted: false
+    };
+}
+
+export function intoChannelWithMapping(
+    midiTrack: TrackJSON,
+    mapping: PercussionMapping,
+    tickScale = 1
+): NoteChannel[] {
+    const channelMap = new Map<Instrument, Note[]>();
+
+    for (const midiNote of midiTrack.notes) {
+        const mappedNote = mapping[midiNote.midi];
+        if (!mappedNote) continue;
+
+        const note: Note = {
+            tick: Math.max(0, Math.round(midiNote.ticks * tickScale)),
+            key: clampToRange(mappedNote.key, 0, 87),
+            velocity: clampToRange(Math.round(midiNote.velocity * 100), 0, 100),
+            pitch: 0
+        };
+
+        if (!channelMap.has(mappedNote.instrument)) {
+            channelMap.set(mappedNote.instrument, []);
+        }
+        channelMap.get(mappedNote.instrument)!.push(note);
+    }
+
+    return Array.from(channelMap.entries()).map(([instrument, entries]) => {
+        const sorted = entries.sort((a, b) => a.tick - b.tick);
+        const sectionLength = sorted.length ? Math.max(...sorted.map((n) => n.tick)) + 1 : 0;
+
+        return {
+            kind: 'note' as const,
+            name: `Percussion ${instrument}`,
+            sections: [
+                {
+                    startingTick: 0,
+                    length: sectionLength,
+                    notes: sorted,
+                    name: 'Main Section'
+                }
+            ],
+            pan: 0,
+            instrument,
+            isMuted: false
+        };
+    });
+}

--- a/src/lib/midi.ts
+++ b/src/lib/midi.ts
@@ -38,33 +38,6 @@ export function guessInstrumentForTrack(track: TrackJSON): Instrument {
     return Instrument.Piano;
 }
 
-export function createDefaultPercussionMapping(track: TrackJSON): PercussionMapping {
-    const mapping: PercussionMapping = {};
-
-    for (const note of track.notes) {
-        const midi = note.midi;
-        if (mapping[midi]) continue;
-
-        mapping[midi] = {
-            instrument: mapPercussionInstrument(midi),
-            key: clampToRange(Math.round(midi - 21), 0, 87)
-        };
-    }
-
-    return mapping;
-}
-
-function mapPercussionInstrument(midi: number): Instrument {
-    if (midi <= 36) return Instrument.BassDrum;
-    if (midi <= 40) return Instrument.SnareDrum;
-    if (midi <= 46) return Instrument.Click;
-    if (midi <= 52) return Instrument.Bell;
-    if (midi <= 60) return Instrument.Guitar;
-    if (midi <= 72) return Instrument.Flute;
-    if (midi <= 84) return Instrument.Bit;
-    return Instrument.Pling;
-}
-
 const MIDI_TO_KEY_OFFSET = 21;
 const OCTAVE_INTERVAL = 12;
 

--- a/src/lib/midi.ts
+++ b/src/lib/midi.ts
@@ -1,6 +1,10 @@
 import type { TrackJSON } from '@tonejs/midi';
 import type { Note, NoteChannel } from './types.js';
-import { Instrument } from './types.js';
+import {
+    Instrument,
+    NOTEBLOCK_HIGHEST_KEY_IN_MIDI,
+    NOTEBLOCK_LOWEST_KEY_IN_MIDI
+} from './types.js';
 
 export interface PercussionTarget {
     instrument: Instrument;

--- a/src/lib/percussion-mapping.ts
+++ b/src/lib/percussion-mapping.ts
@@ -1,0 +1,101 @@
+import type { PercussionMapping } from './midi';
+import { Instrument, NOTEBLOCK_LOWEST_KEY_IN_MIDI } from './types';
+
+/**
+ * Pitch conversion rule from Open Noteblock Studio -> your Noteblock MIDI range.
+ * - If source pitch <= 24: treat as noteblock index (0..24) -> MIDI = 21 + pitch
+ * - Else: treat as absolute MIDI key (use as-is)
+ */
+
+const p = (src: number) => (src <= 24 ? NOTEBLOCK_LOWEST_KEY_IN_MIDI + src : src);
+
+/**
+ * General MIDI Percussion note (Channel 10) -> Noteblock target
+ * Keys not listed are intentionally left unmapped.
+ */
+export const PERCUSSION_MAPPING: PercussionMapping = {
+    // 24–34 (special FX / meta)
+    24: { instrument: Instrument.Bit, key: p(39) }, // Cutting Noise (SFX)
+    25: { instrument: Instrument.SnareDrum, key: p(8) }, // Snare Roll
+    26: { instrument: Instrument.Click, key: p(25) }, // Finger Snap
+    27: { instrument: Instrument.SnareDrum, key: p(18) }, // High Q
+    28: { instrument: Instrument.SnareDrum, key: p(27) }, // Slap
+    29: { instrument: Instrument.Click, key: p(16) }, // Scratch Push
+    30: { instrument: Instrument.Click, key: p(13) }, // Scratch Pull
+    31: { instrument: Instrument.Click, key: p(9) }, // Sticks
+    32: { instrument: Instrument.Click, key: p(6) }, // Square Click
+    33: { instrument: Instrument.Click, key: p(2) }, // Metronome Click
+    34: { instrument: Instrument.Bell, key: p(17) }, // Metronome Bell
+
+    // 35–41
+    35: { instrument: Instrument.BassDrum, key: p(10) }, // Bass Drum 2
+    36: { instrument: Instrument.BassDrum, key: p(6) }, // Bass Drum 1
+    37: { instrument: Instrument.Click, key: p(6) }, // Side Stick
+    38: { instrument: Instrument.SnareDrum, key: p(8) }, // Snare Drum 1
+    39: { instrument: Instrument.Click, key: p(6) }, // Hand Clap
+    40: { instrument: Instrument.SnareDrum, key: p(4) }, // Snare Drum 2
+    41: { instrument: Instrument.BassDrum, key: p(6) }, // Low Tom 2
+
+    // 42–48
+    42: { instrument: Instrument.SnareDrum, key: p(22) }, // Closed Hi-hat
+    43: { instrument: Instrument.BassDrum, key: p(13) }, // Low Tom 1
+    44: { instrument: Instrument.SnareDrum, key: p(22) }, // Pedal Hi-hat
+    45: { instrument: Instrument.BassDrum, key: p(15) }, // Mid Tom 2
+    46: { instrument: Instrument.SnareDrum, key: p(18) }, // Open Hi-hat
+    47: { instrument: Instrument.BassDrum, key: p(20) }, // Mid Tom 1
+    48: { instrument: Instrument.BassDrum, key: p(23) }, // High Tom 2
+
+    // 49–55
+    49: { instrument: Instrument.SnareDrum, key: p(17) }, // Crash Cymbal 1
+    50: { instrument: Instrument.BassDrum, key: p(23) }, // High Tom 1
+    51: { instrument: Instrument.SnareDrum, key: p(24) }, // Ride Cymbal 1
+    52: { instrument: Instrument.SnareDrum, key: p(8) }, // Chinese Cymbal
+    53: { instrument: Instrument.SnareDrum, key: p(13) }, // Ride Bell
+    54: { instrument: Instrument.Click, key: p(18) }, // Tambourine
+    55: { instrument: Instrument.SnareDrum, key: p(18) }, // Splash Cymbal
+
+    // 56–62
+    56: { instrument: Instrument.CowBell, key: p(5) }, // Cowbell
+    57: { instrument: Instrument.SnareDrum, key: p(13) }, // Crash Cymbal 2
+    58: { instrument: Instrument.Click, key: p(2) }, // Vibraslap
+    59: { instrument: Instrument.SnareDrum, key: p(13) }, // Ride Cymbal 2
+    60: { instrument: Instrument.Click, key: p(9) }, // High Bongo
+    61: { instrument: Instrument.Click, key: p(2) }, // Low Bongo
+    62: { instrument: Instrument.Click, key: p(8) }, // Mute High Conga
+
+    // 63–69
+    63: { instrument: Instrument.BassDrum, key: p(22) }, // Open High Conga
+    64: { instrument: Instrument.BassDrum, key: p(15) }, // Low Conga
+    65: { instrument: Instrument.SnareDrum, key: p(13) }, // High Timbale
+    66: { instrument: Instrument.SnareDrum, key: p(8) }, // Low Timbale
+    67: { instrument: Instrument.Xylophone, key: p(12) }, // High Agogo
+    68: { instrument: Instrument.Xylophone, key: p(5) }, // Low Agogo
+    69: { instrument: Instrument.Click, key: p(20) }, // Cabasa
+
+    // 70–76
+    70: { instrument: Instrument.Click, key: p(23) }, // Maracas
+    71: { instrument: Instrument.Flute, key: p(34) }, // Short Whistle
+    72: { instrument: Instrument.Flute, key: p(33) }, // Long  Whistle
+    73: { instrument: Instrument.Click, key: p(17) }, // Short Guiro
+    74: { instrument: Instrument.Click, key: p(11) }, // Long  Guiro
+    75: { instrument: Instrument.Click, key: p(18) }, // Claves
+    76: { instrument: Instrument.Click, key: p(10) }, // High Wood Block
+
+    // 77–83
+    77: { instrument: Instrument.Click, key: p(5) }, // Low Wood Block
+    78: { instrument: Instrument.Didgeridoo, key: p(25) }, // Mute Cuica
+    79: { instrument: Instrument.Didgeridoo, key: p(26) }, // Open Cuica
+    80: { instrument: Instrument.Click, key: p(16) }, // Mute Triangle
+    81: { instrument: Instrument.Bell, key: p(19) }, // Open Triangle
+    82: { instrument: Instrument.SnareDrum, key: p(22) }, // Shaker
+    83: { instrument: Instrument.Bell, key: p(6) }, // Jingle Bell
+
+    // 84
+    84: { instrument: Instrument.Bell, key: p(15) }, // Bell Tree
+    85: { instrument: Instrument.Click, key: p(21) }, // Castanets
+    86: { instrument: Instrument.BassDrum, key: p(14) }, // Mute Surdo
+    87: { instrument: Instrument.BassDrum, key: p(7) }, // Open Surdo
+
+    // Extra SFX from the same table (non-standard GM range often seen below 35):
+    85_000: { instrument: Instrument.Flute, key: p(34) } // (example placeholder if you later add more)
+};

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -62,6 +62,10 @@ export interface Note {
     pitch: number; // -1200 (lower) to 1200 (higher)
 }
 
+export const NOTEBLOCK_LOWEST_KEY_IN_MIDI = 21;
+export const NOTEBLOCK_HIGHEST_KEY_IN_MIDI = 45;
+export const NOTEBLOCK_KEY_CENTER_IN_MIDI = 27; // C3 in Noteblock tuning
+
 export enum Instrument {
     Piano = 0, // Air
     DoubleBass = 1, // Wood

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -3,6 +3,7 @@
     import Button from '$lib/components/ui/button/button.svelte';
     import { readSongFromNbxFile } from '$lib/files';
     import { convertNbsSong } from '$lib/nbs';
+    import MidiImportDialog from '$lib/components/editor/midi-import-dialog.svelte';
     import ResumeSavedSongDialog from '$lib/components/editor/resume-saved-song-dialog.svelte';
     import { player } from '$lib/playback.svelte';
     import {
@@ -21,6 +22,7 @@
     import Music from '~icons/lucide/music-3';
 
     let resumeDialogOpen = $state(false);
+    let midiImportOpen = $state(false);
     let storedSong = $state<StoredSongPayload | null>(null);
 
     onMount(() => {
@@ -206,13 +208,15 @@
         <Button
             variant="outline"
             class="flex h-32 w-32 flex-1 shrink flex-col items-center justify-center text-wrap text-muted-foreground"
-            onclick={() => toast.info('Feature not implemented yet!')}
+            onclick={() => (midiImportOpen = true)}
         >
             <Piano />
             Import MIDI
         </Button>
     </div>
 </main>
+
+<MidiImportDialog bind:open={midiImportOpen} />
 
 {#if storedSong}
     <ResumeSavedSongDialog


### PR DESCRIPTION
Summary
- Add @tone/midi dependency to enable MIDI parsing/handling.
- Introduce Svelte table primitives a MIDI import UI.
- Add per-track transpose support range checks, and automatic octave adjustments- Expose transpose in the import table and UI with controls and summaries.
- Add Checkbox wrapper component and replace native checkboxes in the dialog.
- Improve MIDI import dialog layout, wrapping, and table sizing for long names.
- Add detailed MIDI->Noteblock percussion mapping and pitch-conversion helper.

Related changes
- Lockfile updated with new packages and integrity entries.
- Formatter run on affected files.