### PR TITLE
fix(midi): set note velocity to constant 100 on import

### DIFF
--- a/src/lib/midi.ts
+++ b/src/lib/midi.ts
@@ -79,7 +79,7 @@ export function intoChannelAsInstrument(
             return {
                 tick: Math.max(0, Math.round(midiNote.ticks * tickScale)),
                 key: clampToRange(midiValue - MIDI_TO_KEY_OFFSET, 0, 87),
-                velocity: clampToRange(Math.round(midiNote.velocity * 100), 0, 100),
+                velocity: 100,
                 pitch: 0 // Default pitch adjustment
             } satisfies Note;
         })


### PR DESCRIPTION
Set imported MIDI note velocity to a fixed value of 100 instead
of using the original MIDI velocity scaled to 0–100. This change
forces consistent, maximum playback volume for notes created from
MIDI input and avoids variability introduced by differing MIDI
velocity values.

Keep tick scaling, key clamping, and default pitch behavior intact.