### PR TITLE
fix(datapack): use current player tempo in export dialog

### DIFF
--- a/src/lib/components/editor/datapack-export-dialog.svelte
+++ b/src/lib/components/editor/datapack-export-dialog.svelte
@@ -8,6 +8,7 @@
     import { createSongDatapack, datapackToZip, type Direction } from '$lib/datapack';
     import type { Song } from '$lib/types';
     import { toast } from 'svelte-sonner';
+    import { player } from '$lib/playback.svelte';
 
     interface Props {
         open?: boolean;
@@ -191,7 +192,7 @@
                         id="tempo-override"
                         type="number"
                         bind:value={tempoOverride}
-                        placeholder={song?.tempo.toString() || ''}
+                        placeholder={player.tempo.toString()}
                         step="0.01"
                         min="0"
                     />


### PR DESCRIPTION
Use the active player's tempo as the placeholder for the tempo
override input in the datapack export dialog. Previously the
placeholder relied on the song object, which could be undefined
and might not reflect the tempo currently used by playback. This
change imports the player store and displays player.tempo so the
UI shows the actual playback tempo as the default hint for users.